### PR TITLE
Fix: read Google client ID from Vite env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+VITE_GOOGLE_CLIENT_ID=918141329490-1hgf0gjluv6150suapo736b0tsln63u5.apps.googleusercontent.com
+VITE_BACKEND_URL = 'http://localhost:5000'
+VITE_STRIPE_PUBLISHABLE_KEY=qh3ofUJ9qqA6tnavunDTJSY00ovkitoWt
+CLOUDINARY_CLOUD_NAME=XYZ
+CLOUDINARY_API_KEY=XYZ
+CLOUDINARY_API_SECRET=XY
+
+
+#This project runs on Vite, which requires env variables to be prefixed with VITE_.
+#the previous REACT_APP_GOOGLE_CLIENT_ID variable was not being read at runtime.
+#This PR switches the frontend to VITE_GOOGLE_CLIENT_ID and documents it in .env.example.

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -33,9 +33,9 @@ createRoot(document.getElementById("root")).render(
           <CartInitializer>
             <AppContextProvider>
               <GoogleOAuthProvider
-                clientId="918141329490-1hgf0gjluv6150suapo736b0tsln63u5.apps.googleusercontent.com"
+                clientId={import.meta.env.VITE_GOOGLE_CLIENT_ID}
                 onScriptLoadSuccess={() => {
-                  if (window.google && window.google.accounts) {
+                  if (window.google?.accounts) {
                     window.google.accounts.id.disableAutoSelect();
                   }
                 }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -280,10 +280,10 @@
   resolved "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz"
   integrity sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==
 
-"@esbuild/darwin-arm64@0.24.0":
+"@esbuild/win32-x64@0.24.0":
   version "0.24.0"
-  resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.0.tgz"
-  integrity sha512-CKyDpRbK1hXwv79soeTJNHb5EiG6ct3efd/FTPdzOWdbZZfGhpbcqIpiD0+vwmpu0wTIL97ZRPZu8vUt46nBSw==
+  resolved "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.0.tgz"
+  integrity sha512-7IAFPrjSQIJrGsK6flwg7NFmwBoSTyF3rl7If0hNUFQU4ilTsEPL6GuMuU9BfIWVVGuRnuIidkSMC+c0Otu8IA==
 
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.4.1"
@@ -763,10 +763,10 @@
     redux-thunk "^3.1.0"
     reselect "^5.1.0"
 
-"@rollup/rollup-darwin-arm64@4.27.4":
+"@rollup/rollup-win32-x64-msvc@4.27.4":
   version "4.27.4"
-  resolved "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.27.4.tgz"
-  integrity sha512-PlNiRQapift4LNS8DPUHuDX/IdXiLjf8mc5vdEmUR0fF/pyy2qWwzdLjB+iZquGr8LuN4LnUoSEvKRwjSVYz3Q==
+  resolved "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.27.4.tgz"
+  integrity sha512-3j4jx1TppORdTAoBJRd+/wJRGCPC0ETWkXOecJ6PPZLj6SptXkrXcNqdj0oclbKML6FkQltdz7bBA3rUSirZug==
 
 "@stripe/react-stripe-js@^3.8.1":
   version "3.8.1"
@@ -1819,11 +1819,6 @@ framer-motion@^12.4.3:
     motion-dom "^12.0.0"
     motion-utils "^12.0.0"
     tslib "^2.4.0"
-
-fsevents@~2.3.2, fsevents@~2.3.3:
-  version "2.3.3"
-  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
-  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 function-bind@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
Switch frontend Google client ID to VITE_GOOGLE_CLIENT_ID (Vite required)
Added .env.example documenting required env vars
Local .env intentionally not committed
Hard coded google client id has been removed. 
