### PR TITLE
Fix per-page SEO: real titles, descriptions and self-referencing www canonicals

### DIFF
--- a/src/components/Common/RouteSeo.jsx
+++ b/src/components/Common/RouteSeo.jsx
@@ -20,13 +20,43 @@ const RouteSeo = () => {
   const pathname = location.pathname || "/";
 
   if (
-    pathname.startsWith("/product/") ||
     pathname.startsWith("/blogs/") ||
     pathname.startsWith("/page/") ||
     pathname === "/about" ||
     pathname === "/shop"
   ) {
     return null;
+  }
+
+  // Product detail pages render no SEO of their own, so without this branch
+  // every product URL inherits the homepage title and canonical. The
+  // slug-derived copy is a floor, not a ceiling: as soon as a seo-meta record
+  // exists for entityType "product", the stored values take over.
+  if (pathname.startsWith("/product/")) {
+    const slug = pathname.replace("/product/", "").split("/")[0].split("?")[0];
+    const readable = slug
+      .split("-")
+      .filter(Boolean)
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(" ");
+
+    return (
+      <SeoHelmet
+        entityType="product"
+        entityId={slug}
+        fallback={makeFallback({
+          title: readable
+            ? `${readable} | Super Merch Australia`
+            : "Promotional Products | Super Merch Australia",
+          description: readable
+            ? `${readable} from Super Merch Australia. Custom branded with your logo, with bulk pricing and Australia wide delivery.`
+            : "Custom branded promotional products from Super Merch Australia.",
+          keywords: "promotional products, branded merchandise, custom printed",
+          path: pathname,
+          ogType: "product",
+        })}
+      />
+    );
   }
 
   if (pathname.startsWith("/quote/respond/")) {

--- a/src/components/Common/SeoHelmet.jsx
+++ b/src/components/Common/SeoHelmet.jsx
@@ -1,53 +1,154 @@
-import React from "react";
-import { Helmet } from "react-helmet-async";
+import { useEffect } from "react";
 import useSeoMeta from "../../hooks/useSeoMeta";
 
+const SITE_URL = "https://www.supermerch.com.au";
+
+/**
+ * Force every canonical / og:url onto the one canonical host.
+ *
+ * The site is served from www.supermerch.com.au and the apex domain only
+ * redirects to it. A canonical pointing at the apex tells Google to index a
+ * URL that redirects, which is what caused the July 2026 indexing failure.
+ * Many seo-meta records still store apex URLs, so we normalise here rather
+ * than trusting the stored value.
+ */
+const toCanonicalUrl = (value, pathname) => {
+  const path =
+    pathname ||
+    (typeof window !== "undefined" ? window.location.pathname : "/");
+
+  let url =
+    value && String(value).trim() ? String(value).trim() : `${SITE_URL}${path}`;
+
+  // Make relative values absolute.
+  if (url.startsWith("/")) url = `${SITE_URL}${url}`;
+
+  try {
+    const parsed = new URL(url);
+    parsed.protocol = "https:";
+    if (parsed.hostname === "supermerch.com.au") {
+      parsed.hostname = "www.supermerch.com.au";
+    }
+    // Canonicals should be clean: no query string, no fragment.
+    parsed.search = "";
+    parsed.hash = "";
+    // Strip a trailing slash except on the root.
+    if (parsed.pathname.length > 1 && parsed.pathname.endsWith("/")) {
+      parsed.pathname = parsed.pathname.replace(/\/+$/, "");
+    }
+    return parsed.toString();
+  } catch {
+    return `${SITE_URL}${path}`;
+  }
+};
+
+/**
+ * Create or update a meta tag.
+ *
+ * index.html ships some tags as property= and some as name=. We reuse
+ * whichever already exists so we update the static tag instead of appending
+ * a duplicate beside it.
+ */
+const setMeta = (attr, key, content) => {
+  if (typeof document === "undefined") return;
+
+  let el = document.head.querySelector(`meta[${attr}="${key}"]`);
+  if (!el) {
+    const other = attr === "name" ? "property" : "name";
+    el = document.head.querySelector(`meta[${other}="${key}"]`);
+  }
+
+  if (!content) {
+    // Only remove tags this component created; leave the static ones alone.
+    if (el && el.dataset.smSeo === "true") el.remove();
+    return;
+  }
+
+  if (!el) {
+    el = document.createElement("meta");
+    el.setAttribute(attr, key);
+    el.dataset.smSeo = "true";
+    document.head.appendChild(el);
+  }
+
+  el.setAttribute("content", content);
+};
+
+const setCanonical = (href) => {
+  if (typeof document === "undefined" || !href) return;
+
+  let el = document.head.querySelector('link[rel="canonical"]');
+  if (!el) {
+    el = document.createElement("link");
+    el.setAttribute("rel", "canonical");
+    document.head.appendChild(el);
+  }
+  el.setAttribute("href", href);
+};
+
+/**
+ * Applies per-page SEO tags directly to <head>.
+ *
+ * This previously rendered <Helmet> from react-helmet-async. The component
+ * was mounting correctly (the seo-meta request fired on every route) but
+ * Helmet never wrote anything to the document, so every page kept the static
+ * tags from index.html and served the homepage title, description and
+ * canonical. Writing the tags in an effect is deterministic, needs no
+ * provider, and drops the dependency.
+ *
+ * Props are unchanged, so no call site needs editing.
+ */
 const SeoHelmet = ({ entityType, entityId, fallback = {} }) => {
   const { seoData } = useSeoMeta(entityType, entityId);
 
-  const title = seoData?.metaTitle || fallback.title;
-  const description = seoData?.metaDescription || fallback.description;
-  const keywords = seoData?.keywords || fallback.keywords;
+  const title = seoData?.metaTitle || fallback.title || "";
+  const description = seoData?.metaDescription || fallback.description || "";
+  const keywords = seoData?.keywords || fallback.keywords || "";
   const ogTitle = seoData?.ogTitle || title;
   const ogDescription = seoData?.ogDescription || description;
-  const ogImage = seoData?.ogImage || fallback.ogImage;
-  const canonicalUrl = seoData?.canonicalUrl || fallback.canonicalUrl;
-  const computedCanonical =
-    canonicalUrl ||
-    (typeof window !== "undefined" ? window.location.href.split("#")[0] : "");
-
-  const ogUrl = fallback.ogUrl || computedCanonical;
+  const ogImage = seoData?.ogImage || fallback.ogImage || "";
   const ogType = fallback.ogType || "website";
-  const twitterCard = fallback.twitterCard || "summary_large_image";
   const siteName = fallback.siteName || "Super Merch";
   const robots = fallback.robots || "index, follow";
-
-  return (
-    <Helmet>
-      {title && <title>{title}</title>}
-      {description && <meta name="description" content={description} />}
-      {keywords && <meta name="keywords" content={keywords} />}
-      {robots && <meta name="robots" content={robots} />}
-
-      {computedCanonical && <link rel="canonical" href={computedCanonical} />}
-
-      {ogType && <meta property="og:type" content={ogType} />}
-      {ogTitle && <meta property="og:title" content={ogTitle} />}
-      {ogDescription && (
-        <meta property="og:description" content={ogDescription} />
-      )}
-      {ogImage && <meta property="og:image" content={ogImage} />}
-      {ogUrl && <meta property="og:url" content={ogUrl} />}
-      {siteName && <meta property="og:site_name" content={siteName} />}
-
-      {twitterCard && <meta name="twitter:card" content={twitterCard} />}
-      {ogTitle && <meta name="twitter:title" content={ogTitle} />}
-      {ogDescription && (
-        <meta name="twitter:description" content={ogDescription} />
-      )}
-      {ogImage && <meta name="twitter:image" content={ogImage} />}
-    </Helmet>
+  const canonical = toCanonicalUrl(
+    seoData?.canonicalUrl || fallback.canonicalUrl
   );
+
+  useEffect(() => {
+    if (title) document.title = title;
+
+    setMeta("name", "description", description);
+    setMeta("name", "keywords", keywords);
+    setMeta("name", "robots", robots);
+
+    setCanonical(canonical);
+
+    setMeta("property", "og:title", ogTitle);
+    setMeta("property", "og:description", ogDescription);
+    setMeta("property", "og:image", ogImage);
+    setMeta("property", "og:url", canonical);
+    setMeta("property", "og:type", ogType);
+    setMeta("property", "og:site_name", siteName);
+
+    setMeta("name", "twitter:card", ogImage ? "summary_large_image" : "summary");
+    setMeta("name", "twitter:title", ogTitle);
+    setMeta("name", "twitter:description", ogDescription);
+    setMeta("name", "twitter:image", ogImage);
+    setMeta("name", "twitter:url", canonical);
+  }, [
+    title,
+    description,
+    keywords,
+    robots,
+    canonical,
+    ogTitle,
+    ogDescription,
+    ogImage,
+    ogType,
+    siteName,
+  ]);
+
+  return null;
 };
 
 export default SeoHelmet;


### PR DESCRIPTION
## What was wrong

The 16 July audit reported 100% of pages as not indexable. The www fixes from that day are live and Google has started indexing again, but two things were still broken in production:

**1. Per-page SEO never reached the document.** `SeoHelmet` rendered `<Helmet>` from `react-helmet-async`. The component mounted correctly (the `/api/seo-meta/by-entity/...` request fires on every route) but Helmet never wrote anything to `<head>`. Every page therefore kept the static tags from `index.html` and served the homepage title, description and canonical. Verified live on `/shop`, `/about` and `/product/*` — all three returned `<link rel="canonical" href="https://www.supermerch.com.au/">`, telling Google every page is a duplicate of the homepage.

**2. Product pages had no SEO at all.** `/product/*` was in the early-return list in `RouteSeo`, and neither `ProductPageResolver`, `ProducPage` nor `ClothingHeadwearProductPage` renders a `SeoHelmet`. Product URLs are the long tail, and every one of them was pointing its canonical at the homepage.

## What this changes

**`SeoHelmet.jsx`** — writes `title`, `description`, `keywords`, `robots`, `canonical`, `og:*` and `twitter:*` straight to `<head>` in an effect instead of going through Helmet. Deterministic, no provider needed, and it drops the dependency. Existing tags from `index.html` are updated in place rather than duplicated. **Props are unchanged, so no call site needed editing.**

**`RouteSeo.jsx`** — removes `/product/` from the early return and adds a product branch with a self-referencing canonical and slug-derived title. The slug copy is a floor, not a ceiling: as soon as a `seo-meta` record exists for `entityType: "product"`, the stored values take over.

## Canonical normalisation, and why it is in here

Every `seo-meta` record currently in the database stores an **apex** canonical:

| entity | stored canonicalUrl |
|---|---|
| cmsPage/home | `https://supermerch.com.au/` |
| category/shop | `https://supermerch.com.au/shop` |
| cmsPage/about | `https://supermerch.com.au/about` |
| cmsPage/contact | `https://supermerch.com.au/contact` |
| category/promotional | `https://supermerch.com.au/promotional` |
| category/sales | `https://supermerch.com.au/sales` |
| category/australia-made | `https://supermerch.com.au/australia-made` |
| cmsPage/faqs | `https://supermerch.com.au/faqs` |

The apex only redirects to www. Shipping fix 1 without handling this would have made every page emit a canonical pointing at a redirecting URL — recreating the exact failure the July audit caught. `toCanonicalUrl()` forces https, forces the www host, and strips query strings and trailing slashes.

This is a safety net, **not** a substitute for correcting the records. The stored values are being fixed separately in the admin panel.

## Still outstanding (not code, cannot be fixed in this PR)

`https://supermerch.com.au/` still returns a **307 Temporary Redirect** to www. Measured today:

```
http://supermerch.com.au/      308 Permanent  ->  https://supermerch.com.au/
https://supermerch.com.au/     307 Temporary  ->  https://www.supermerch.com.au/   <-- needs to be 308
https://www.supermerch.com.au/ 200 OK
```

Google treats 307 like 302, so it passes no ranking signal and every backlink built to the apex domain is currently wasted. Fix is in **Vercel → supermerch-frontend → Settings → Domains**: keep `www` primary and set the apex redirect to permanent (308).

## How to verify after deploy

On `/shop`, `/about` and any `/product/*` page, confirm each has its **own** title, its **own** meta description, and `<link rel="canonical">` equal to its **own** www URL. Then resubmit `https://www.supermerch.com.au/sitemap.xml` in Search Console and request indexing.

Both changed files were syntax-checked with esbuild.