### PR TITLE
Draft: Add Promodata-powered product SEO

### DIFF
--- a/src/__tests__/productSeo.test.js
+++ b/src/__tests__/productSeo.test.js
@@ -45,7 +45,7 @@ describe("buildProductSeo", () => {
     expect(result.structuredData[0]).toMatchObject({
       "@type": "Product",
       name: "Ocean Bottle",
-      sku: "42",
+      sku: "BOT-42",
       offers: { "@type": "Offer", price: "6.25", priceCurrency: "AUD" },
     });
     expect(result.structuredData[1]["@type"]).toBe("BreadcrumbList");

--- a/src/__tests__/productSeo.test.js
+++ b/src/__tests__/productSeo.test.js
@@ -7,6 +7,7 @@ import {
 
 const completeProduct = {
   meta: { id: 42 },
+  pricingSummary: { finalMinPrice: 6.25 },
   overview: {
     hero_image: "https://images.example.test/bottle.jpg",
     supplier: "Acme",
@@ -67,9 +68,33 @@ describe("buildProductSeo", () => {
     expect(result.structuredData).toEqual([]);
   });
 
-  it("does not invent an Offer when Promodata has no valid price", () => {
+  it("does not invent an Offer when Promodata has no authoritative price", () => {
     const result = buildProductSeo({
-      data: { ...completeProduct, product: { ...completeProduct.product, prices: null } },
+      data: { ...completeProduct, pricingSummary: null },
+      pathname: "/product/ocean-bottle",
+      slug: "ocean-bottle",
+    });
+
+    expect(result.structuredData[0].offers).toBeUndefined();
+  });
+
+  it("does not publish undecorated base pricing as an Offer", () => {
+    const result = buildProductSeo({
+      data: {
+        ...completeProduct,
+        pricingSummary: null,
+        product: {
+          ...completeProduct.product,
+          prices: {
+            price_groups: [
+              {
+                base_price: { price_breaks: [{ price: "6.25" }] },
+                additions: [{ price_breaks: [{ price: "2.50" }] }],
+              },
+            ],
+          },
+        },
+      },
       pathname: "/product/ocean-bottle",
       slug: "ocean-bottle",
     });

--- a/src/__tests__/productSeo.test.js
+++ b/src/__tests__/productSeo.test.js
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildProductSeo, cleanSeoText } from "@/utils/productSeo";
+import {
+  buildProductSeo,
+  cleanSeoText,
+  getProductCategoryBreadcrumb,
+} from "@/utils/productSeo";
 
 const completeProduct = {
   meta: { id: 42 },
@@ -67,6 +71,95 @@ describe("buildProductSeo", () => {
     });
 
     expect(result.structuredData[0].offers).toBeUndefined();
+  });
+
+  it("noindexes discontinued products and omits their Offer", () => {
+    const result = buildProductSeo({
+      data: { ...completeProduct, meta: { ...completeProduct.meta, discontinued: "true" } },
+      pathname: "/product/ocean-bottle",
+      slug: "ocean-bottle",
+    });
+
+    expect(result.fallback.robots).toBe("noindex, follow");
+    expect(result.structuredData[0].offers).toBeUndefined();
+  });
+
+  it("uses supplier_brand as Brand and never substitutes the supplier", () => {
+    const branded = buildProductSeo({
+      data: {
+        ...completeProduct,
+        product: { ...completeProduct.product, supplier_brand: "CamelBak" },
+      },
+      pathname: "/product/ocean-bottle",
+      slug: "ocean-bottle",
+    });
+    const supplierOnly = buildProductSeo({
+      data: completeProduct,
+      pathname: "/product/ocean-bottle",
+      slug: "ocean-bottle",
+    });
+
+    expect(branded.structuredData[0].brand).toEqual({
+      "@type": "Brand",
+      name: "CamelBak",
+    });
+    expect(supplierOnly.structuredData[0].brand).toBeUndefined();
+  });
+
+  it.each([
+    ["clothing", "/Clothing"],
+    ["headwear", "/Headwear"],
+  ])("adds a crawlable %s breadcrumb URL for clothing/headwear products", (navGroup, path) => {
+    const data = {
+      ...completeProduct,
+      product: {
+        ...completeProduct.product,
+        categorisation: {
+          promodata_product_type: {
+            type_group_id: "GROUP-1",
+            type_name: navGroup === "clothing" ? "Polo Shirts" : "Caps",
+          },
+        },
+      },
+    };
+    const categoryBreadcrumb = getProductCategoryBreadcrumb(data, [
+      { id: "GROUP-1", name: navGroup === "clothing" ? "Clothing" : "Headwear", navGroup },
+    ]);
+    const result = buildProductSeo({
+      data,
+      pathname: "/product/ocean-bottle",
+      slug: "ocean-bottle",
+      categoryBreadcrumb,
+    });
+    const items = result.structuredData[1].itemListElement;
+
+    expect(categoryBreadcrumb.url).toBe(`https://www.supermerch.com.au${path}`);
+    expect(items.map((item) => item.name)).toEqual([
+      "Home",
+      "Shop",
+      navGroup === "clothing" ? "Clothing" : "Headwear",
+      "Ocean Bottle",
+    ]);
+    expect(items[2].item).toBe(`https://www.supermerch.com.au${path}`);
+  });
+
+  it("omits a category crumb when category metadata has no crawlable route", () => {
+    const categoryBreadcrumb = getProductCategoryBreadcrumb(completeProduct, [
+      { id: "unknown", name: "Unknown", navGroup: "other" },
+    ]);
+    const result = buildProductSeo({
+      data: completeProduct,
+      pathname: "/product/ocean-bottle",
+      slug: "ocean-bottle",
+      categoryBreadcrumb,
+    });
+
+    expect(categoryBreadcrumb).toBeNull();
+    expect(result.structuredData[1].itemListElement.map((item) => item.name)).toEqual([
+      "Home",
+      "Shop",
+      "Ocean Bottle",
+    ]);
   });
 });
 

--- a/src/__tests__/productSeo.test.js
+++ b/src/__tests__/productSeo.test.js
@@ -42,6 +42,8 @@ describe("buildProductSeo", () => {
     );
     expect(result.fallback.robots).toBe("index, follow");
     expect(result.imageAlt).toBe("Ocean Bottle – Drink Bottles");
+    expect(result.fallback.ogImage).toBe("https://images.example.test/bottle.jpg");
+    expect(result.fallback.ogImageAlt).toBe("Ocean Bottle – Drink Bottles");
     expect(result.structuredData[0]).toMatchObject({
       "@type": "Product",
       name: "Ocean Bottle",
@@ -60,6 +62,8 @@ describe("buildProductSeo", () => {
 
     expect(result.fallback.robots).toBe("noindex, follow");
     expect(result.fallback.title).toContain("mystery item");
+    expect(result.fallback.ogImage).toBe("https://www.supermerch.com.au/logo-teal.png");
+    expect(result.fallback.ogImageAlt).toBe("Super Merch Australia logo");
     expect(result.structuredData).toEqual([]);
   });
 

--- a/src/__tests__/productSeo.test.js
+++ b/src/__tests__/productSeo.test.js
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { buildProductSeo, cleanSeoText } from "@/utils/productSeo";
+
+const completeProduct = {
+  meta: { id: 42 },
+  overview: {
+    hero_image: "https://images.example.test/bottle.jpg",
+    supplier: "Acme",
+    sku_number: "BOT-42",
+  },
+  product: {
+    name: "Ocean Bottle",
+    description: "<p>Reusable &amp; insulated bottle.</p>",
+    categorisation: {
+      promodata_product_type: { type_name: "Drink Bottles" },
+    },
+    prices: {
+      price_groups: [
+        { base_price: { price_breaks: [{ price: "8.50" }, { price: "6.25" }] } },
+      ],
+    },
+  },
+};
+
+describe("buildProductSeo", () => {
+  it("builds indexable metadata and Product, Offer, and Breadcrumb schemas", () => {
+    const result = buildProductSeo({
+      data: completeProduct,
+      pathname: "/product/ocean-bottle",
+      slug: "ocean-bottle",
+    });
+
+    expect(result.entityId).toBe("42");
+    expect(result.fallback.title).toContain("Ocean Bottle");
+    expect(result.fallback.description).toBe("Reusable & insulated bottle.");
+    expect(result.fallback.canonicalUrl).toBe(
+      "https://www.supermerch.com.au/product/ocean-bottle",
+    );
+    expect(result.fallback.robots).toBe("index, follow");
+    expect(result.imageAlt).toBe("Ocean Bottle – Drink Bottles");
+    expect(result.structuredData[0]).toMatchObject({
+      "@type": "Product",
+      name: "Ocean Bottle",
+      sku: "42",
+      offers: { "@type": "Offer", price: "6.25", priceCurrency: "AUD" },
+    });
+    expect(result.structuredData[1]["@type"]).toBe("BreadcrumbList");
+  });
+
+  it("noindexes incomplete product data and omits unsafe Product markup", () => {
+    const result = buildProductSeo({
+      data: null,
+      pathname: "/product/mystery-item",
+      slug: "mystery-item",
+    });
+
+    expect(result.fallback.robots).toBe("noindex, follow");
+    expect(result.fallback.title).toContain("mystery item");
+    expect(result.structuredData).toEqual([]);
+  });
+
+  it("does not invent an Offer when Promodata has no valid price", () => {
+    const result = buildProductSeo({
+      data: { ...completeProduct, product: { ...completeProduct.product, prices: null } },
+      pathname: "/product/ocean-bottle",
+      slug: "ocean-bottle",
+    });
+
+    expect(result.structuredData[0].offers).toBeUndefined();
+  });
+});
+
+describe("cleanSeoText", () => {
+  it("turns Promodata HTML into safe plain text", () => {
+    expect(cleanSeoText("<p>A &amp; B</p>\n<p>products</p>")).toBe("A & B products");
+  });
+});

--- a/src/components/Common/RouteSeo.jsx
+++ b/src/components/Common/RouteSeo.jsx
@@ -20,43 +20,13 @@ const RouteSeo = () => {
   const pathname = location.pathname || "/";
 
   if (
+    pathname.startsWith("/product/") ||
     pathname.startsWith("/blogs/") ||
     pathname.startsWith("/page/") ||
     pathname === "/about" ||
     pathname === "/shop"
   ) {
     return null;
-  }
-
-  // Product detail pages render no SEO of their own, so without this branch
-  // every product URL inherits the homepage title and canonical. The
-  // slug-derived copy is a floor, not a ceiling: as soon as a seo-meta record
-  // exists for entityType "product", the stored values take over.
-  if (pathname.startsWith("/product/")) {
-    const slug = pathname.replace("/product/", "").split("/")[0].split("?")[0];
-    const readable = slug
-      .split("-")
-      .filter(Boolean)
-      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-      .join(" ");
-
-    return (
-      <SeoHelmet
-        entityType="product"
-        entityId={slug}
-        fallback={makeFallback({
-          title: readable
-            ? `${readable} | Super Merch Australia`
-            : "Promotional Products | Super Merch Australia",
-          description: readable
-            ? `${readable} from Super Merch Australia. Custom branded with your logo, with bulk pricing and Australia wide delivery.`
-            : "Custom branded promotional products from Super Merch Australia.",
-          keywords: "promotional products, branded merchandise, custom printed",
-          path: pathname,
-          ogType: "product",
-        })}
-      />
-    );
   }
 
   if (pathname.startsWith("/quote/respond/")) {

--- a/src/components/Common/SeoHelmet.jsx
+++ b/src/components/Common/SeoHelmet.jsx
@@ -114,6 +114,7 @@ const SeoHelmet = ({
   const ogTitle = seoData?.ogTitle || title;
   const ogDescription = seoData?.ogDescription || description;
   const ogImage = seoData?.ogImage || fallback.ogImage || "";
+  const ogImageAlt = seoData?.ogImageAlt || fallback.ogImageAlt || "";
   const ogType = fallback.ogType || "website";
   const siteName = fallback.siteName || "Super Merch";
   const robots = fallback.robots || "index, follow";
@@ -133,6 +134,7 @@ const SeoHelmet = ({
     setMeta("property", "og:title", ogTitle);
     setMeta("property", "og:description", ogDescription);
     setMeta("property", "og:image", ogImage);
+    setMeta("property", "og:image:alt", ogImageAlt);
     setMeta("property", "og:url", canonical);
     setMeta("property", "og:type", ogType);
     setMeta("property", "og:site_name", siteName);
@@ -141,6 +143,7 @@ const SeoHelmet = ({
     setMeta("name", "twitter:title", ogTitle);
     setMeta("name", "twitter:description", ogDescription);
     setMeta("name", "twitter:image", ogImage);
+    setMeta("name", "twitter:image:alt", ogImageAlt);
     setMeta("name", "twitter:url", canonical);
 
     document.head.querySelectorAll('script[data-sm-seo-jsonld="true"]').forEach((node) => node.remove());
@@ -164,6 +167,7 @@ const SeoHelmet = ({
     ogTitle,
     ogDescription,
     ogImage,
+    ogImageAlt,
     ogType,
     siteName,
     structuredData,

--- a/src/components/Common/SeoHelmet.jsx
+++ b/src/components/Common/SeoHelmet.jsx
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import PropTypes from "prop-types";
 import useSeoMeta from "../../hooks/useSeoMeta";
 
 const SITE_URL = "https://www.supermerch.com.au";
@@ -98,7 +99,13 @@ const setCanonical = (href) => {
  *
  * Props are unchanged, so no call site needs editing.
  */
-const SeoHelmet = ({ entityType, entityId, fallback = {} }) => {
+const SeoHelmet = ({
+  entityType,
+  entityId,
+  fallback = {},
+  structuredData = [],
+  forceCanonicalUrl,
+}) => {
   const { seoData } = useSeoMeta(entityType, entityId);
 
   const title = seoData?.metaTitle || fallback.title || "";
@@ -111,7 +118,7 @@ const SeoHelmet = ({ entityType, entityId, fallback = {} }) => {
   const siteName = fallback.siteName || "Super Merch";
   const robots = fallback.robots || "index, follow";
   const canonical = toCanonicalUrl(
-    seoData?.canonicalUrl || fallback.canonicalUrl
+    forceCanonicalUrl || seoData?.canonicalUrl || fallback.canonicalUrl
   );
 
   useEffect(() => {
@@ -135,6 +142,19 @@ const SeoHelmet = ({ entityType, entityId, fallback = {} }) => {
     setMeta("name", "twitter:description", ogDescription);
     setMeta("name", "twitter:image", ogImage);
     setMeta("name", "twitter:url", canonical);
+
+    document.head.querySelectorAll('script[data-sm-seo-jsonld="true"]').forEach((node) => node.remove());
+    structuredData.filter(Boolean).forEach((value) => {
+      const script = document.createElement("script");
+      script.type = "application/ld+json";
+      script.dataset.smSeoJsonld = "true";
+      script.textContent = JSON.stringify(value).replace(/</g, "\\u003c");
+      document.head.appendChild(script);
+    });
+
+    return () => {
+      document.head.querySelectorAll('script[data-sm-seo-jsonld="true"]').forEach((node) => node.remove());
+    };
   }, [
     title,
     description,
@@ -146,9 +166,18 @@ const SeoHelmet = ({ entityType, entityId, fallback = {} }) => {
     ogImage,
     ogType,
     siteName,
+    structuredData,
   ]);
 
   return null;
+};
+
+SeoHelmet.propTypes = {
+  entityType: PropTypes.string,
+  entityId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  fallback: PropTypes.object,
+  structuredData: PropTypes.arrayOf(PropTypes.object),
+  forceCanonicalUrl: PropTypes.string,
 };
 
 export default SeoHelmet;

--- a/src/components/clothingHeadwearPdp/ProductGallery.jsx
+++ b/src/components/clothingHeadwearPdp/ProductGallery.jsx
@@ -467,7 +467,7 @@ export default function ProductGallery({
                                             >
                                                 <img
                                                     src={image}
-                                                    alt={`View ${index + 1}`}
+                                                    alt={`${productName || "Promotional product"} thumbnail view ${index + 1}`}
                                                     className="h-full w-full object-contain p-0.5"
                                                 />
                                             </button>

--- a/src/components/product/ProductDetails/index.jsx
+++ b/src/components/product/ProductDetails/index.jsx
@@ -1,6 +1,5 @@
 import LoadingOverlay from "@/components/Common/LoadingOverlay";
 import RecommendationsStrip from "@/components/Common/RecommendationsStrip";
-import SeoHelmet from "@/components/Common/SeoHelmet";
 import {
   getProductPrice,
   isProductCategory,
@@ -1279,14 +1278,6 @@ const ProductDetails = () => {
 
   const mainContent = (
     <>
-      <SeoHelmet
-        entityType="product"
-        entityId={productId}
-        fallback={{
-          title: product?.name ? `${product.name} - SuperMerch Australia` : "SuperMerch Australia",
-          description: product?.description?.substring(0, 160) || "Premium promotional products and custom merchandise",
-        }}
-      />
       {/* Add to cart notification bar */}
       <AnimatePresence>
         {showAddToCartNotification && (
@@ -1344,7 +1335,7 @@ const ProductDetails = () => {
                       <div className="flex-shrink-0 w-24 h-24 rounded-lg overflow-hidden bg-gray-100 border border-gray-200">
                         <img
                           src={activeImage || normalizedImages[0] || noimage}
-                          alt={product?.name}
+                          alt={`${product?.name || "Promotional product"} selected configuration`}
                           className="w-full h-full object-cover"
                         />
                       </div>
@@ -1526,7 +1517,7 @@ const ProductDetails = () => {
                 >
                   <img
                     src={item}
-                    alt={`${product?.name} ${index + 1}`}
+                    alt={`${product?.name || "Promotional product"} product view ${index + 1}`}
                     className="w-full object-contain"
                   />
                 </div>
@@ -1560,7 +1551,7 @@ const ProductDetails = () => {
                 >
                   <img
                     src={item}
-                    alt={`Thumbnail ${index}`}
+                    alt={`${product?.name || "Promotional product"} thumbnail view ${index + 1}`}
                     className="w-full h-full object-cover bg-gray-50"
                   />
                 </button>
@@ -1586,7 +1577,7 @@ const ProductDetails = () => {
             >
               <img
                 src={activeImage}
-                alt={product?.name}
+                alt={`${product?.name || "Promotional product"} main product view`}
                 className="w-full max-h-[600px] max-w-full object-contain transition-transform duration-300 ease-out group-hover:scale-150"
               />
             </div>

--- a/src/components/product/ProductDetails/index.jsx
+++ b/src/components/product/ProductDetails/index.jsx
@@ -629,8 +629,6 @@ const ProductDetails = () => {
     }
   }, [product, normalizedImages]);
 
-  // SEO meta is now handled by <SeoHelmet> in JSX — falls back to product name/description
-
   // Keyboard event listeners for Shift + A
   useEffect(() => {
     const handleKeyDown = (e) => {

--- a/src/components/product/ProductSeo.jsx
+++ b/src/components/product/ProductSeo.jsx
@@ -1,15 +1,21 @@
-import { useMemo } from "react";
+import { useContext, useMemo } from "react";
 import PropTypes from "prop-types";
 import { useLocation, useParams } from "react-router-dom";
 import SeoHelmet from "@/components/Common/SeoHelmet";
-import { buildProductSeo } from "@/utils/productSeo";
+import { ProductsContext } from "@/context/ProductsContext";
+import { buildProductSeo, getProductCategoryBreadcrumb } from "@/utils/productSeo";
 
 const ProductSeo = ({ product }) => {
   const { id: slug } = useParams();
   const { pathname } = useLocation();
+  const { v1categories } = useContext(ProductsContext) || {};
+  const categoryBreadcrumb = useMemo(
+    () => getProductCategoryBreadcrumb(product, v1categories),
+    [product, v1categories],
+  );
   const seo = useMemo(
-    () => buildProductSeo({ data: product, pathname, slug }),
-    [product, pathname, slug],
+    () => buildProductSeo({ data: product, pathname, slug, categoryBreadcrumb }),
+    [product, pathname, slug, categoryBreadcrumb],
   );
 
   return (

--- a/src/components/product/ProductSeo.jsx
+++ b/src/components/product/ProductSeo.jsx
@@ -1,0 +1,30 @@
+import { useMemo } from "react";
+import PropTypes from "prop-types";
+import { useLocation, useParams } from "react-router-dom";
+import SeoHelmet from "@/components/Common/SeoHelmet";
+import { buildProductSeo } from "@/utils/productSeo";
+
+const ProductSeo = ({ product }) => {
+  const { id: slug } = useParams();
+  const { pathname } = useLocation();
+  const seo = useMemo(
+    () => buildProductSeo({ data: product, pathname, slug }),
+    [product, pathname, slug],
+  );
+
+  return (
+    <SeoHelmet
+      entityType="product"
+      entityId={seo.entityId}
+      fallback={seo.fallback}
+      structuredData={seo.structuredData}
+      forceCanonicalUrl={seo.fallback.canonicalUrl}
+    />
+  );
+};
+
+ProductSeo.propTypes = {
+  product: PropTypes.object,
+};
+
+export default ProductSeo;

--- a/src/hooks/useSeoMeta.js
+++ b/src/hooks/useSeoMeta.js
@@ -24,6 +24,9 @@ export default function useSeoMeta(entityType, entityId) {
     }
 
     let cancelled = false;
+    // Do not briefly apply the previous entity's manual overrides while the
+    // newly resolved product ID is loading.
+    setSeoData(null);
     setLoading(true);
 
     axios

--- a/src/pages/ClothingHeadwearWorkwearPdp.jsx
+++ b/src/pages/ClothingHeadwearWorkwearPdp.jsx
@@ -6,7 +6,6 @@ import { toast } from "react-toastify";
 import { motion, AnimatePresence } from "framer-motion";
 import { IoClose } from "react-icons/io5";
 
-import SeoHelmet from "@/components/Common/SeoHelmet";
 import RecommendationsStrip from "@/components/Common/RecommendationsStrip";
 import ProductGallery from "@/components/clothingHeadwearPdp/ProductGallery";
 import ProductInfo from "@/components/clothingHeadwearPdp/ProductInfo";
@@ -798,15 +797,6 @@ export default function ClothingHeadwearWorkwearPdp() {
 
   return (
     <>
-      <SeoHelmet
-        entityType="product"
-        entityId={productId}
-        fallback={{
-          title: `${workwearProduct.name} | Super Merch`,
-          description: singleProduct?.product?.description_plain || workwearProduct.name,
-          ogImage: workwearProduct.primaryImage?.imageUrl,
-        }}
-      />
       <div className="py-2 sm:py-4 md:py-6 bg-gradient-to-b from-[#F8FAFC] via-white to-[#F8FAFC] min-h-screen">
         <div className="max-w-7xl mx-auto px-3 sm:px-4 lg:px-8">
           <div className="grid grid-cols-1 lg:grid-cols-[1fr_0.9fr] gap-4 sm:gap-6 lg:gap-12 mb-6 sm:mb-8">

--- a/src/pages/ProducPage.jsx
+++ b/src/pages/ProducPage.jsx
@@ -1,38 +1,16 @@
 import TabsButtons from "@/components/Home/ProducsTabs/ShopOurBestSellers";
 import ProductNavigate from "../components/product/ProductNavigate";
 import ProductDetails from "@/components/product/ProductDetails/index";
-import { useState, useEffect, useContext } from "react";
-import { useLocation, useParams } from "react-router-dom";
-import axios from "axios";
-import { AppContext } from "@/context/AppContext";
+import { useEffect } from "react";
+import PropTypes from "prop-types";
+import { useLocation } from "react-router-dom";
 
-const ProducPage = () => {
-  const { id } = useParams(); // Get slug from URL path
-  const { backendUrl } = useContext(AppContext);
-  const [product, setProduct] = useState(null);
+const ProducPage = ({ product }) => {
   const { pathname } = useLocation();
 
   useEffect(() => {
     window.scrollTo(0, 0);
   }, [pathname]);
-
-  useEffect(() => {
-    if (!id) return;
-    const fetchProduct = async () => {
-      try {
-        // Pass the slug (or ID) to the backend
-        const { data } = await axios.get(
-          `${backendUrl}/api/single-product/${id}`
-        );
-        if (data) {
-          setProduct(data.data);
-        }
-      } catch (error) {
-        console.log(error);
-      }
-    };
-    fetchProduct();
-  }, [id, backendUrl]);
 
   return (
     <div>
@@ -44,6 +22,10 @@ const ProducPage = () => {
       </div>
     </div>
   );
+};
+
+ProducPage.propTypes = {
+  product: PropTypes.object,
 };
 
 export default ProducPage;

--- a/src/pages/ProductPageResolver.jsx
+++ b/src/pages/ProductPageResolver.jsx
@@ -8,6 +8,7 @@ import { ProductsContext } from "@/context/ProductsContext";
 import { getCategoryMetaForNavGroup } from "@/utils/categoryMeta";
 import { ProductPrefetchContext } from "@/context/ProductPrefetchContext";
 import LoadingOverlay from "@/components/Common/LoadingOverlay";
+import ProductSeo from "@/components/product/ProductSeo";
 
 const CLOTHING_HEADWEAR_NAV_GROUPS = new Set(["clothing", "headwear"]);
 const normalizeNavGroup = (value) => {
@@ -112,21 +113,27 @@ const ProductPageResolver = () => {
 
   if (isChecking) {
     return (
-      <LoadingOverlay
-        title="Loading product"
-        subtitle="Checking category and loading product details…"
-        variant="product"
-        showBrand={true}
-      />
+      <>
+        <ProductSeo product={null} />
+        <LoadingOverlay
+          title="Loading product"
+          subtitle="Checking category and loading product details…"
+          variant="product"
+          showBrand={true}
+        />
+      </>
     );
   }
 
-  return isClothingOrHeadwear ? (
+  return (
     <ProductPrefetchContext.Provider value={prefetchValue}>
-      <ClothingHeadwearProductPage />
+      <ProductSeo product={singleProduct} />
+      {isClothingOrHeadwear ? (
+        <ClothingHeadwearProductPage />
+      ) : (
+        <ProducPage product={singleProduct} />
+      )}
     </ProductPrefetchContext.Provider>
-  ) : (
-    <ProducPage />
   );
 };
 

--- a/src/utils/productSeo.js
+++ b/src/utils/productSeo.js
@@ -75,14 +75,7 @@ export const getProductSeoImages = (data) => {
 
 const getLowestPrice = (data) => {
   const summaryPrice = Number(data?.pricingSummary?.finalMinPrice);
-  if (Number.isFinite(summaryPrice) && summaryPrice > 0) return summaryPrice;
-
-  const groups = data?.product?.prices?.price_groups;
-  const prices = (Array.isArray(groups) ? groups : []).flatMap((group) =>
-    (group?.base_price?.price_breaks || []).map((entry) => Number(entry?.price)),
-  );
-  const valid = prices.filter((price) => Number.isFinite(price) && price > 0);
-  return valid.length ? Math.min(...valid) : null;
+  return Number.isFinite(summaryPrice) && summaryPrice > 0 ? summaryPrice : null;
 };
 
 const getAvailability = (data) => {

--- a/src/utils/productSeo.js
+++ b/src/utils/productSeo.js
@@ -5,6 +5,38 @@ const DEFAULT_DESCRIPTION =
 const firstText = (...values) =>
   values.find((value) => typeof value === "string" && value.trim())?.trim() || "";
 
+const isTrue = (value) => value === true || String(value).toLowerCase() === "true";
+
+const CATEGORY_ROUTES = {
+  clothing: "/Clothing",
+  headwear: "/Headwear",
+  promotional: "/promotional",
+};
+
+export const getProductCategoryBreadcrumb = (data, categories = []) => {
+  const groupId = String(
+    data?.product?.categorisation?.promodata_product_type?.type_group_id || "",
+  ).trim();
+  if (!groupId || !Array.isArray(categories)) return null;
+
+  const exact = categories.find((entry) => String(entry?.id || "") === groupId);
+  const category =
+    (exact?.navGroup ? exact : null) ||
+    categories.find(
+      (entry) =>
+        Array.isArray(entry?.allowedTypeGroupIds) &&
+        entry.allowedTypeGroupIds.map(String).includes(groupId),
+    );
+  const navGroup = String(category?.navGroup || "").toLowerCase().trim();
+  const path = CATEGORY_ROUTES[navGroup];
+  if (!path) return null;
+
+  return {
+    name: firstText(category?.name, navGroup[0].toUpperCase() + navGroup.slice(1)),
+    url: `${SITE_URL}${path}`,
+  };
+};
+
 export const cleanSeoText = (value) =>
   String(value || "")
     .replace(/<[^>]*>/g, " ")
@@ -60,12 +92,15 @@ const getAvailability = (data) => {
     data?.product?.stockQty,
     data?.product?.totalStock,
   ];
-  const explicit = values.map(Number).find(Number.isFinite);
+  const explicit = values
+    .filter((value) => value !== null && value !== undefined && value !== "")
+    .map(Number)
+    .find(Number.isFinite);
   if (explicit === undefined) return null;
   return explicit > 0 ? "https://schema.org/InStock" : "https://schema.org/OutOfStock";
 };
 
-export const buildProductSeo = ({ data, pathname, slug }) => {
+export const buildProductSeo = ({ data, pathname, slug, categoryBreadcrumb = null }) => {
   const product = data?.product || {};
   const overview = data?.overview || {};
   const name = firstText(product.name, overview.name, overview.originalName);
@@ -79,9 +114,16 @@ export const buildProductSeo = ({ data, pathname, slug }) => {
     product.categorisation?.product_type?.type_name,
     product.categorisation?.supplier_category,
   );
-  const brand = firstText(product.brand?.name, overview.brand, overview.supplier);
+  const brand = firstText(
+    typeof product.supplier_brand === "string"
+      ? product.supplier_brand
+      : product.supplier_brand?.name,
+    product.brand?.name,
+    overview.brand,
+  );
   const canonicalUrl = `${SITE_URL}${pathname || `/product/${slug || ""}`}`;
   const hasProductIdentity = Boolean(data && name && productId);
+  const isDiscontinued = isTrue(data?.meta?.discontinued) || isTrue(product.discontinued);
   const displayName = name || cleanSeoText(String(slug || "").replace(/-/g, " ")) || "Promotional Product";
   const metaDescription = (description || `${displayName}. ${DEFAULT_DESCRIPTION}`).slice(0, 160);
 
@@ -97,7 +139,7 @@ export const buildProductSeo = ({ data, pathname, slug }) => {
     url: canonicalUrl,
   };
   const price = getLowestPrice(data);
-  if (price) {
+  if (price && !isDiscontinued) {
     productSchema.offers = {
       "@type": "Offer",
       url: canonicalUrl,
@@ -111,7 +153,14 @@ export const buildProductSeo = ({ data, pathname, slug }) => {
     { "@type": "ListItem", position: 1, name: "Home", item: `${SITE_URL}/` },
     { "@type": "ListItem", position: 2, name: "Shop", item: `${SITE_URL}/shop` },
   ];
-  if (category) breadcrumbs.push({ "@type": "ListItem", position: 3, name: category });
+  if (categoryBreadcrumb?.name && categoryBreadcrumb?.url) {
+    breadcrumbs.push({
+      "@type": "ListItem",
+      position: 3,
+      name: categoryBreadcrumb.name,
+      item: categoryBreadcrumb.url,
+    });
+  }
   breadcrumbs.push({
     "@type": "ListItem",
     position: breadcrumbs.length + 1,
@@ -129,7 +178,7 @@ export const buildProductSeo = ({ data, pathname, slug }) => {
       ogImage: images[0] || "",
       ogType: "product",
       siteName: "Super Merch",
-      robots: hasProductIdentity ? "index, follow" : "noindex, follow",
+      robots: hasProductIdentity && !isDiscontinued ? "index, follow" : "noindex, follow",
     },
     structuredData: hasProductIdentity
       ? [

--- a/src/utils/productSeo.js
+++ b/src/utils/productSeo.js
@@ -1,0 +1,141 @@
+const SITE_URL = "https://www.supermerch.com.au";
+const DEFAULT_DESCRIPTION =
+  "Custom branded promotional products from Super Merch Australia, with bulk pricing and Australia-wide delivery.";
+
+const firstText = (...values) =>
+  values.find((value) => typeof value === "string" && value.trim())?.trim() || "";
+
+export const cleanSeoText = (value) =>
+  String(value || "")
+    .replace(/<[^>]*>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/\s+/g, " ")
+    .trim();
+
+const imageUrl = (image) => {
+  if (typeof image === "string") return image.trim();
+  return firstText(
+    image?.url,
+    image?.original,
+    image?.large_square,
+    image?.medium_square,
+    image?.small_square,
+  );
+};
+
+export const getProductSeoImages = (data) => {
+  const product = data?.product || {};
+  const candidates = [
+    data?.overview?.hero_image,
+    ...(Array.isArray(product.images) ? product.images : []),
+    ...(Array.isArray(product.image_data) ? product.image_data : []),
+    ...(Array.isArray(product.colours?.list)
+      ? product.colours.list.map((colour) => colour?.image)
+      : []),
+  ];
+  return [...new Set(candidates.map(imageUrl).filter(Boolean))];
+};
+
+const getLowestPrice = (data) => {
+  const summaryPrice = Number(data?.pricingSummary?.finalMinPrice);
+  if (Number.isFinite(summaryPrice) && summaryPrice > 0) return summaryPrice;
+
+  const groups = data?.product?.prices?.price_groups;
+  const prices = (Array.isArray(groups) ? groups : []).flatMap((group) =>
+    (group?.base_price?.price_breaks || []).map((entry) => Number(entry?.price)),
+  );
+  const valid = prices.filter((price) => Number.isFinite(price) && price > 0);
+  return valid.length ? Math.min(...valid) : null;
+};
+
+const getAvailability = (data) => {
+  const values = [
+    data?.stock,
+    data?.stockQty,
+    data?.totalStock,
+    data?.product?.stock,
+    data?.product?.stockQty,
+    data?.product?.totalStock,
+  ];
+  const explicit = values.map(Number).find(Number.isFinite);
+  if (explicit === undefined) return null;
+  return explicit > 0 ? "https://schema.org/InStock" : "https://schema.org/OutOfStock";
+};
+
+export const buildProductSeo = ({ data, pathname, slug }) => {
+  const product = data?.product || {};
+  const overview = data?.overview || {};
+  const name = firstText(product.name, overview.name, overview.originalName);
+  const description = cleanSeoText(
+    firstText(product.description, overview.description, product.short_description),
+  );
+  const images = getProductSeoImages(data);
+  const productId = firstText(String(data?.meta?.id || ""), overview.sku_number, product.code);
+  const category = firstText(
+    product.categorisation?.promodata_product_type?.type_name,
+    product.categorisation?.product_type?.type_name,
+    product.categorisation?.supplier_category,
+  );
+  const brand = firstText(product.brand?.name, overview.brand, overview.supplier);
+  const canonicalUrl = `${SITE_URL}${pathname || `/product/${slug || ""}`}`;
+  const hasProductIdentity = Boolean(data && name && productId);
+  const displayName = name || cleanSeoText(String(slug || "").replace(/-/g, " ")) || "Promotional Product";
+  const metaDescription = (description || `${displayName}. ${DEFAULT_DESCRIPTION}`).slice(0, 160);
+
+  const productSchema = {
+    "@context": "https://schema.org",
+    "@type": "Product",
+    name: displayName,
+    description: description || metaDescription,
+    ...(images.length ? { image: images } : {}),
+    ...(productId ? { sku: productId } : {}),
+    ...(brand ? { brand: { "@type": "Brand", name: brand } } : {}),
+    ...(category ? { category } : {}),
+    url: canonicalUrl,
+  };
+  const price = getLowestPrice(data);
+  if (price) {
+    productSchema.offers = {
+      "@type": "Offer",
+      url: canonicalUrl,
+      priceCurrency: "AUD",
+      price: price.toFixed(2),
+      ...(getAvailability(data) ? { availability: getAvailability(data) } : {}),
+    };
+  }
+
+  const breadcrumbs = [
+    { "@type": "ListItem", position: 1, name: "Home", item: `${SITE_URL}/` },
+    { "@type": "ListItem", position: 2, name: "Shop", item: `${SITE_URL}/shop` },
+  ];
+  if (category) breadcrumbs.push({ "@type": "ListItem", position: 3, name: category });
+  breadcrumbs.push({
+    "@type": "ListItem",
+    position: breadcrumbs.length + 1,
+    name: displayName,
+    item: canonicalUrl,
+  });
+
+  return {
+    entityId: productId || slug,
+    imageAlt: `${displayName}${category ? ` – ${category}` : " promotional product"}`,
+    fallback: {
+      title: `${displayName} | Custom Branded | Super Merch Australia`,
+      description: metaDescription,
+      canonicalUrl,
+      ogImage: images[0] || "",
+      ogType: "product",
+      siteName: "Super Merch",
+      robots: hasProductIdentity ? "index, follow" : "noindex, follow",
+    },
+    structuredData: hasProductIdentity
+      ? [
+          productSchema,
+          { "@context": "https://schema.org", "@type": "BreadcrumbList", itemListElement: breadcrumbs },
+        ]
+      : [],
+  };
+};

--- a/src/utils/productSeo.js
+++ b/src/utils/productSeo.js
@@ -1,6 +1,8 @@
 const SITE_URL = "https://www.supermerch.com.au";
 const DEFAULT_DESCRIPTION =
   "Custom branded promotional products from Super Merch Australia, with bulk pricing and Australia-wide delivery.";
+const DEFAULT_SOCIAL_IMAGE = `${SITE_URL}/logo-teal.png`;
+const DEFAULT_SOCIAL_IMAGE_ALT = "Super Merch Australia logo";
 
 const firstText = (...values) =>
   values.find((value) => typeof value === "string" && value.trim())?.trim() || "";
@@ -126,6 +128,7 @@ export const buildProductSeo = ({ data, pathname, slug, categoryBreadcrumb = nul
   const hasProductIdentity = Boolean(data && name && productId);
   const isDiscontinued = isTrue(data?.meta?.discontinued) || isTrue(product.discontinued);
   const displayName = name || cleanSeoText(String(slug || "").replace(/-/g, " ")) || "Promotional Product";
+  const imageAlt = `${displayName}${category ? ` – ${category}` : " promotional product"}`;
   const metaDescription = (description || `${displayName}. ${DEFAULT_DESCRIPTION}`).slice(0, 160);
 
   const productSchema = {
@@ -171,12 +174,13 @@ export const buildProductSeo = ({ data, pathname, slug, categoryBreadcrumb = nul
 
   return {
     entityId: productId || slug,
-    imageAlt: `${displayName}${category ? ` – ${category}` : " promotional product"}`,
+    imageAlt,
     fallback: {
       title: `${displayName} | Custom Branded | Super Merch Australia`,
       description: metaDescription,
       canonicalUrl,
-      ogImage: images[0] || "",
+      ogImage: images[0] || DEFAULT_SOCIAL_IMAGE,
+      ogImageAlt: images[0] ? imageAlt : DEFAULT_SOCIAL_IMAGE_ALT,
       ogType: "product",
       siteName: "Super Merch",
       robots: hasProductIdentity && !isDiscontinued ? "index, follow" : "noindex, follow",

--- a/src/utils/productSeo.js
+++ b/src/utils/productSeo.js
@@ -109,6 +109,7 @@ export const buildProductSeo = ({ data, pathname, slug, categoryBreadcrumb = nul
   );
   const images = getProductSeoImages(data);
   const productId = firstText(String(data?.meta?.id || ""), overview.sku_number, product.code);
+  const sku = firstText(overview.sku_number, product.code);
   const category = firstText(
     product.categorisation?.promodata_product_type?.type_name,
     product.categorisation?.product_type?.type_name,
@@ -133,7 +134,7 @@ export const buildProductSeo = ({ data, pathname, slug, categoryBreadcrumb = nul
     name: displayName,
     description: description || metaDescription,
     ...(images.length ? { image: images } : {}),
-    ...(productId ? { sku: productId } : {}),
+    ...(sku ? { sku } : {}),
     ...(brand ? { brand: { "@type": "Brand", name: brand } } : {}),
     ...(category ? { category } : {}),
     url: canonicalUrl,


### PR DESCRIPTION
### Motivation
- Product pages were using slug-only fallbacks and sometimes inherited homepage meta; SEO needs unique product titles/descriptions, self-referencing canonicals, structured data and safe fallbacks when Promodata is incomplete.
- Preserve existing manual SEO overrides from the `seo-meta` records while enforcing a canonical host and preventing stale overrides from leaking between product navigations.
- Emit Product/Offer/Breadcrumb JSON-LD only when the Promodata record is reliable, and ensure images and gallery alt text are meaningful for accessibility and SEO.

### Description
- Add `src/utils/productSeo.js` to derive product metadata and JSON-LD (Product, Offer, BreadcrumbList) from Promodata, with safe fallbacks and rules to omit unsafe Offer/Product markup when identity or pricing is missing.
- Add `src/components/product/ProductSeo.jsx` which builds the Promodata SEO payload and renders it via the existing `SeoHelmet` contract.
- Extend `src/components/Common/SeoHelmet.jsx` to accept `structuredData` and `forceCanonicalUrl`, write JSON-LD script nodes to <head>, and continue to prefer manual `seo-meta` overrides when present.
- Wire product SEO into the page lifecycle by updating `src/pages/ProductPageResolver.jsx` to render `ProductSeo` (uses the already-prefetched product when available) and pass the resolved product into `ProducPage`/product components, removing the older slug-only fallback in `RouteSeo`.
- Make Product Details and gallery images have descriptive alt text for primary images, gallery views and thumbnails (`ProductDetails` and `ProductGallery` changes).
- Update `src/hooks/useSeoMeta.js` to clear previous SEO data while a new entity is loading so manual overrides do not briefly carry over.
- Add unit tests in `src/__tests__/productSeo.test.js` to cover complete, incomplete, HTML-rich and price-less Promodata records.
- Add PropTypes to new components and small call-site adjustments to accept the prefetched product rather than always refetching.

### Testing
- `npm run build` — production build completed successfully (Vite reported the repository's existing large-chunk advisory but build succeeded).
- Lint: targeted lint check for the changed/new files (`npx eslint` on the updated paths) passed; repository-wide `npm run lint` still fails due to a pre-existing backlog of issues unrelated to this change (reported ~1,895 issues including build artifacts).
- Unit tests: `npm test -- --run src/__tests__/productSeo.test.js src/__tests__/categoryMeta.test.js` passed (23 tests total); the new SEO test file passes locally.
- Full test run: the new tests and existing category tests pass, but an unrelated pre-existing suite (`ProductCard.discount.test.jsx`) cannot load its undeclared `@testing-library/react` dependency in this environment (pre-existing test setup issue).

This change is on a feature branch and opened as a draft PR for review; it is not merged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6673fd2cc883219b050d8809d0ad75)