### PR TITLE
Fix live product sitemap generation

### DIFF
--- a/api/product-sitemap.js
+++ b/api/product-sitemap.js
@@ -76,6 +76,8 @@ export default async function handler(req, res) {
     console.error(`Failed to build product sitemap page ${page}:`, error);
     res.setHeader("Content-Type", "application/xml; charset=utf-8");
     res.setHeader("Cache-Control", "no-store");
-    res.status(503).send("Sitemap temporarily unavailable");
+    res.status(503).send(
+      `<?xml version="1.0" encoding="UTF-8"?>\n<error>Sitemap temporarily unavailable</error>`,
+    );
   }
 }

--- a/api/product-sitemap.js
+++ b/api/product-sitemap.js
@@ -1,6 +1,10 @@
 const SITE_URL = "https://www.supermerch.com.au";
-const BACKEND_URL = process.env.BACKEND_URL || process.env.VITE_BACKEND_URL || "https://api.supermerch.com.au";
+const BACKEND_URL =
+  process.env.BACKEND_URL ||
+  process.env.VITE_BACKEND_URL ||
+  "https://api.supermerch.com.au";
 const PAGE_SIZE = 500;
+const BACKEND_TIMEOUT_MS = 30000;
 
 const slugify = (value) =>
   String(value || "")
@@ -17,11 +21,13 @@ const escapeXml = (value) =>
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&apos;");
 
-const isDiscontinued = (product) =>
-  product?.meta?.discontinued === true ||
-  String(product?.meta?.discontinued).toLowerCase() === "true" ||
-  product?.product?.discontinued === true ||
-  String(product?.product?.discontinued).toLowerCase() === "true";
+const formatLastModified = (value) => {
+  if (!value) return "";
+  const date = new Date(value);
+  return Number.isNaN(date.getTime())
+    ? ""
+    : `<lastmod>${escapeXml(date.toISOString())}</lastmod>`;
+};
 
 export default async function handler(req, res) {
   const page = Number(req.query.page);
@@ -32,37 +38,44 @@ export default async function handler(req, res) {
 
   try {
     const response = await fetch(
-      `${BACKEND_URL}/api/client-products?page=${page}&limit=${PAGE_SIZE}&filter=true`,
-      { signal: AbortSignal.timeout(8000) },
+      `${BACKEND_URL}/api/sitemap-products?page=${page}&limit=${PAGE_SIZE}`,
+      { signal: AbortSignal.timeout(BACKEND_TIMEOUT_MS) },
     );
-    if (!response.ok) throw new Error(`Product API returned ${response.status}`);
-    const payload = await response.json();
+    if (!response.ok) throw new Error(`Sitemap product API returned ${response.status}`);
 
-    const entries = (Array.isArray(payload.data) ? payload.data : [])
-      .filter((product) => !isDiscontinued(product))
+    const payload = await response.json();
+    if (!payload?.success || !Array.isArray(payload.data)) {
+      throw new Error("Sitemap product API returned an invalid response");
+    }
+
+    const entries = payload.data
       .map((product) => {
-        const id = product?.meta?.id;
-        const name =
-          product?.product?.name ||
-          product?.overview?.name ||
-          product?.overview?.originalName;
+        const id = product?.id;
+        const name = product?.name;
         if (id === undefined || id === null || !name) return "";
-        const productSlug = slugify(product?.product?.slug || product?.overview?.slug || name);
+
+        const productSlug = slugify(product.slug || name);
+        if (!productSlug) return "";
+
         const path = `/product/${productSlug}/${encodeURIComponent(String(id))}`;
-        const lastmod = product?.updatedAt
-          ? `<lastmod>${escapeXml(new Date(product.updatedAt).toISOString())}</lastmod>`
-          : "";
+        const lastmod = formatLastModified(product.updatedAt);
         return `  <url><loc>${escapeXml(`${SITE_URL}${path}`)}</loc>${lastmod}<changefreq>weekly</changefreq><priority>0.6</priority></url>`;
       })
       .filter(Boolean)
       .join("\n");
 
     res.setHeader("Content-Type", "application/xml; charset=utf-8");
-    res.setHeader("Cache-Control", "public, s-maxage=3600, stale-while-revalidate=86400");
+    res.setHeader(
+      "Cache-Control",
+      "public, s-maxage=3600, stale-while-revalidate=86400",
+    );
     res.status(200).send(
       `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${entries}\n</urlset>`,
     );
-  } catch {
+  } catch (error) {
+    console.error(`Failed to build product sitemap page ${page}:`, error);
+    res.setHeader("Content-Type", "application/xml; charset=utf-8");
+    res.setHeader("Cache-Control", "no-store");
     res.status(503).send("Sitemap temporarily unavailable");
   }
 }

--- a/api/sitemap-index.js
+++ b/api/sitemap-index.js
@@ -1,6 +1,10 @@
 const SITE_URL = "https://www.supermerch.com.au";
-const BACKEND_URL = process.env.BACKEND_URL || process.env.VITE_BACKEND_URL || "https://api.supermerch.com.au";
+const BACKEND_URL =
+  process.env.BACKEND_URL ||
+  process.env.VITE_BACKEND_URL ||
+  "https://api.supermerch.com.au";
 const PAGE_SIZE = 500;
+const BACKEND_TIMEOUT_MS = 30000;
 
 const xml = (value) =>
   `<?xml version="1.0" encoding="UTF-8"?>\n${value}`;
@@ -8,23 +12,20 @@ const xml = (value) =>
 export default async function handler(req, res) {
   try {
     const response = await fetch(
-      `${BACKEND_URL}/api/client-products?page=1&limit=${PAGE_SIZE}&filter=true`,
-      { signal: AbortSignal.timeout(8000) },
+      `${BACKEND_URL}/api/sitemap-products?page=1&limit=${PAGE_SIZE}`,
+      { signal: AbortSignal.timeout(BACKEND_TIMEOUT_MS) },
     );
-    if (!response.ok) throw new Error(`Product API returned ${response.status}`);
+    if (!response.ok) throw new Error(`Sitemap product API returned ${response.status}`);
+
     const payload = await response.json();
+    if (!payload?.success || !payload?.pagination) {
+      throw new Error("Sitemap product API returned an invalid response");
+    }
+
     const totalPages = Math.max(
       1,
-      Number(payload.total_pages || payload.totalPages) ||
-        Math.ceil(
-          Number(
-            payload.item_count ||
-              payload.totalCount ||
-              payload.total_count ||
-              payload.pagination?.totalCount ||
-              0,
-          ) / PAGE_SIZE,
-        ),
+      Number(payload.pagination.totalPages) ||
+        Math.ceil(Number(payload.pagination.totalCount || 0) / PAGE_SIZE),
     );
 
     const productMaps = Array.from(
@@ -34,14 +35,19 @@ export default async function handler(req, res) {
     ).join("\n");
 
     res.setHeader("Content-Type", "application/xml; charset=utf-8");
-    res.setHeader("Cache-Control", "public, s-maxage=3600, stale-while-revalidate=86400");
+    res.setHeader(
+      "Cache-Control",
+      "public, s-maxage=3600, stale-while-revalidate=86400",
+    );
     res.status(200).send(
       xml(
         `<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n  <sitemap><loc>${SITE_URL}/sitemap-static.xml</loc></sitemap>\n${productMaps}\n</sitemapindex>`,
       ),
     );
-  } catch {
+  } catch (error) {
+    console.error("Failed to build sitemap index:", error);
     res.setHeader("Content-Type", "application/xml; charset=utf-8");
+    res.setHeader("Cache-Control", "no-store");
     res.status(503).send(xml(`<error>Sitemap temporarily unavailable</error>`));
   }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,12 @@
 {
+  "functions": {
+    "api/sitemap-index.js": {
+      "maxDuration": 60
+    },
+    "api/product-sitemap.js": {
+      "maxDuration": 60
+    }
+  },
   "rewrites": [
     {
       "source": "/sitemap.xml",


### PR DESCRIPTION
## Why
`/sitemap.xml` currently returns HTTP 503 because the Vercel sitemap functions call the full storefront product API with an 8-second deadline. That endpoint performs work that sitemap generation does not need and is vulnerable to backend cold starts.

## Changes
- consume the dedicated lightweight `/api/sitemap-products` backend feed
- validate the feed response before publishing XML
- use the backend's filtered pagination metadata for shard discovery
- build canonical product URLs from the compact feed
- tolerate invalid `updatedAt` values without failing an entire shard
- use a bounded 30-second backend deadline and no-store error responses
- allow sitemap functions up to 60 seconds for cold-start recovery

## Dependency
Backend PR #41 is merged into `bweb-dev` at `45a88fd7d8033816dc7ade0e49de17dd7e14e2b1`. The frontend PR should merge only after the new backend endpoint is live and returns a valid feed.

## Verification
After deployment:
- `/sitemap.xml` returns HTTP 200 XML sitemap index
- `/sitemaps/products-1.xml` returns HTTP 200 XML with canonical `/product/:slug/:id` URLs
- missing/discontinued/ignored products are absent
- `robots.txt` continues to reference `/sitemap.xml`