### PR TITLE
Add dynamic content SEO and live content sitemap

### DIFF
--- a/api/content-sitemap.js
+++ b/api/content-sitemap.js
@@ -1,0 +1,139 @@
+const SITE_URL = "https://www.supermerch.com.au";
+const BACKEND_URL =
+  process.env.BACKEND_URL ||
+  process.env.VITE_BACKEND_URL ||
+  "https://api.supermerch.com.au";
+
+const STATIC_PATHS = [
+  "/",
+  "/shop",
+  "/promotional",
+  "/Clothing",
+  "/Headwear",
+  "/australia-made",
+  "/24hr-production",
+  "/return-gifts",
+  "/deals",
+  "/hot-deals",
+  "/clearance",
+  "/category",
+  "/all-blogs",
+  "/about",
+  "/contact",
+  "/faqs",
+  "/artwork-policy",
+  "/refund-policy",
+  "/privacy",
+  "/terms",
+  "/help-center",
+  "/pms",
+];
+
+const escapeXml = (value) =>
+  String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+
+const fetchJson = async (url) => {
+  try {
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(10000),
+    });
+    if (!response.ok) return null;
+    return response.json();
+  } catch {
+    return null;
+  }
+};
+
+const normaliseRows = (payload, keys) => {
+  for (const key of keys) {
+    if (Array.isArray(payload?.[key])) return payload[key];
+  }
+  return [];
+};
+
+const lastModified = (value) => {
+  if (!value) return "";
+  const date = new Date(value);
+  return Number.isNaN(date.getTime())
+    ? ""
+    : `<lastmod>${escapeXml(date.toISOString())}</lastmod>`;
+};
+
+export default async function handler(_req, res) {
+  const [collectionPayload, blogPayload, dealPayload] = await Promise.all([
+    fetchJson(`${BACKEND_URL}/api/public/collections`),
+    fetchJson(`${BACKEND_URL}/api/blogs/get-blogs`),
+    fetchJson(`${BACKEND_URL}/api/frontend/deals`),
+  ]);
+
+  const entries = STATIC_PATHS.map((path) => ({
+    path,
+    changefreq: ["/deals", "/hot-deals", "/clearance"].includes(path)
+      ? "daily"
+      : "weekly",
+    priority: path === "/" ? "1.0" : "0.7",
+  }));
+
+  const collections = normaliseRows(collectionPayload, ["data", "collections"]);
+  for (const collection of collections) {
+    if (!collection?.slug || collection?.isActive === false) continue;
+    entries.push({
+      path: `/collections/${encodeURIComponent(collection.slug)}`,
+      updatedAt: collection.updatedAt,
+      changefreq: "weekly",
+      priority: "0.7",
+    });
+  }
+
+  const blogs = normaliseRows(blogPayload, ["data", "blogs"]);
+  for (const blog of blogs) {
+    const identifier = blog?._id || blog?.id;
+    if (!identifier || blog?.isActive === false || blog?.status === "draft") continue;
+    entries.push({
+      path: `/blogs/${encodeURIComponent(identifier)}`,
+      updatedAt: blog.updatedAt || blog.publishedAt,
+      changefreq: "monthly",
+      priority: "0.6",
+    });
+  }
+
+  const deals = normaliseRows(dealPayload, ["data", "deals"]);
+  for (const deal of deals) {
+    if (!deal?.slug || deal?.isActive === false) continue;
+    entries.push({
+      path: `/deals/${encodeURIComponent(deal.slug)}`,
+      updatedAt: deal.updatedAt,
+      changefreq: "daily",
+      priority: "0.7",
+    });
+  }
+
+  const seen = new Set();
+  const urls = entries
+    .filter(({ path }) => {
+      if (seen.has(path)) return false;
+      seen.add(path);
+      return true;
+    })
+    .map(
+      ({ path, updatedAt, changefreq, priority }) =>
+        `  <url><loc>${escapeXml(`${SITE_URL}${path}`)}</loc>${lastModified(
+          updatedAt,
+        )}<changefreq>${changefreq}</changefreq><priority>${priority}</priority></url>`,
+    )
+    .join("\n");
+
+  res.setHeader("Content-Type", "application/xml; charset=utf-8");
+  res.setHeader(
+    "Cache-Control",
+    "public, s-maxage=3600, stale-while-revalidate=86400",
+  );
+  res.status(200).send(
+    `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls}\n</urlset>`,
+  );
+}

--- a/api/product-page.js
+++ b/api/product-page.js
@@ -55,6 +55,49 @@ const imageUrl = (image) => {
   );
 };
 
+const detailValue = (details, names) => {
+  const accepted = new Set(names.map((name) => name.toLowerCase()));
+  return cleanText(
+    (Array.isArray(details) ? details : []).find((item) =>
+      accepted.has(cleanText(item?.name).toLowerCase()),
+    )?.detail,
+  );
+};
+
+const productAttributes = (details) => {
+  const categorisation = details.categorisation || {};
+  const category = cleanText(
+    categorisation?.promodata_product_type?.type_name ||
+      categorisation?.product_type?.type_name ||
+      categorisation?.supplier_category,
+  );
+  const material =
+    detailValue(details.details, ["Material", "Materials"]) ||
+    cleanText(
+      (categorisation.promodata_attributes || [])
+        .find((value) => /^material\s*:/i.test(String(value)))
+        ?.replace(/^material\s*:/i, ""),
+    );
+  const color = cleanText(
+    (details.colours?.list || [])
+      .flatMap((item) => item?.colours || item?.name || [])
+      .filter(Boolean)
+      .slice(0, 8)
+      .join(", "),
+  );
+  return {
+    category,
+    material,
+    color,
+    capacity: detailValue(details.details, ["Capacity", "Volume"]),
+    branding: detailValue(details.details, [
+      "Branding Options",
+      "Decoration Options",
+      "Branding",
+    ]),
+  };
+};
+
 const removeMeta = (html, key) => {
   const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   return html.replace(
@@ -231,6 +274,7 @@ export default async function handler(req, res) {
     "";
   const discontinued =
     isTrue(product?.meta?.discontinued) || isTrue(details.discontinued);
+  const attributes = productAttributes(details);
 
   if (discontinued) {
     res.setHeader("Content-Type", "text/html; charset=utf-8");
@@ -242,7 +286,16 @@ export default async function handler(req, res) {
   const generatedTitle = `${name} | Custom Branded | Super Merch Australia`;
   const generatedDescription =
     description ||
-    `${name}. Custom branded promotional products from Super Merch Australia.`;
+    [
+      name,
+      attributes.category ? `Custom branded ${attributes.category.toLowerCase()}` : "Custom branded promotional product",
+      attributes.material ? `made from ${attributes.material}` : "",
+      attributes.capacity ? `with ${attributes.capacity} capacity` : "",
+      "from Super Merch Australia.",
+    ]
+      .filter(Boolean)
+      .join(" ")
+      .slice(0, 160);
   const seoOverride = await getSeoOverride(productId);
   const title = cleanText(seoOverride?.metaTitle) || generatedTitle;
   const metaDescription =
@@ -264,6 +317,10 @@ export default async function handler(req, res) {
     image: image === DEFAULT_IMAGE ? undefined : [image],
     sku: sku || undefined,
     brand: brand ? { "@type": "Brand", name: brand } : undefined,
+    category: attributes.category || undefined,
+    material: attributes.material || undefined,
+    color: attributes.color || undefined,
+    mpn: details.code || undefined,
     url: canonical,
   };
   const price = Number(product?.pricingSummary?.finalMinPrice);

--- a/api/seo-page.js
+++ b/api/seo-page.js
@@ -1,0 +1,260 @@
+const SITE_URL = "https://www.supermerch.com.au";
+const BACKEND_URL =
+  process.env.BACKEND_URL ||
+  process.env.VITE_BACKEND_URL ||
+  "https://api.supermerch.com.au";
+const DEFAULT_IMAGE = `${SITE_URL}/logo-teal.png`;
+
+const STATIC_PAGES = {
+  "/": ["cmsPage", "home", "Super Merch Australia", "Custom promotional products, branded merchandise, workwear, corporate gifts and awards for Australian organisations."],
+  "/shop": ["category", "shop", "Shop Promotional Products | Super Merch Australia", "Browse custom promotional products and branded merchandise for Australian businesses, events and teams."],
+  "/promotional": ["category", "promotional", "Promotional Products Australia | Super Merch", "Browse custom promotional products and branded merchandise for Australian businesses, events, teams and campaigns."],
+  "/Clothing": ["category", "Clothing", "Custom Branded Clothing Australia | Super Merch", "Shop custom branded polos, shirts, jackets, workwear and apparel for Australian teams and businesses."],
+  "/Headwear": ["category", "Headwear", "Custom Branded Headwear Australia | Super Merch", "Browse custom caps, hats, beanies and branded headwear for Australian organisations and events."],
+  "/return-gifts": ["category", "return-gifts", "Custom Return Gifts Australia | Super Merch", "Discover practical custom return gifts and branded giveaways for celebrations, events and organisations."],
+  "/24hr-production": ["category", "24hr-production", "24-Hour Promotional Products Australia | Super Merch", "Browse promotional products available with rapid production options for urgent Australian orders."],
+  "/deals": ["category", "deals", "Deals and Offers | Super Merch Australia", "View current Super Merch deals on custom promotional products and branded merchandise."],
+  "/hot-deals": ["category", "hot-deals", "Promotional Product Deals | Super Merch Australia", "Explore current promotional merchandise deals and value offers from Super Merch Australia."],
+  "/australia-made": ["category", "australia-made", "Australian-Made Promotional Products | Super Merch", "Shop Australian-made promotional products and locally produced branded merchandise."],
+  "/clearance": ["category", "clearance", "Promotional Product Clearance | Super Merch Australia", "Browse clearance promotional products and branded merchandise while stocks last."],
+  "/category": ["category", "category", "Promotional Product Categories | Super Merch Australia", "Explore promotional product categories, branded merchandise, corporate gifts and custom apparel."],
+  "/about": ["cmsPage", "about", "About Super Merch Australia", "Learn about Super Merch and our approach to promotional products, uniforms, corporate gifts and branded merchandise."],
+  "/contact": ["cmsPage", "contact", "Contact Super Merch Australia", "Contact Super Merch for promotional products, uniforms, corporate gifts, awards and branded merchandise."],
+  "/all-blogs": ["cmsPage", "all-blogs", "Promotional Products Blog | Super Merch Australia", "Read practical guides and ideas about promotional products, corporate gifts, branded apparel and merchandise."],
+  "/faqs": ["cmsPage", "faqs", "Frequently Asked Questions | Super Merch Australia", "Find answers about artwork, branding, delivery, minimum quantities and ordering from Super Merch."],
+  "/artwork-policy": ["cmsPage", "artwork-policy", "Artwork Policy | Super Merch Australia", "Review Super Merch artwork requirements for custom branded promotional products and apparel."],
+  "/refund-policy": ["cmsPage", "refund-policy", "Refund Policy | Super Merch Australia", "Review the Super Merch refund and returns policy."],
+  "/privacy": ["cmsPage", "privacy", "Privacy Policy | Super Merch Australia", "Read the Super Merch Australia privacy policy."],
+  "/terms": ["cmsPage", "terms", "Terms and Conditions | Super Merch Australia", "Read the Super Merch Australia website and ordering terms and conditions."],
+  "/help-center": ["cmsPage", "help-center", "Help Centre | Super Merch Australia", "Get help with Super Merch products, artwork, ordering and delivery."],
+  "/pms": ["cmsPage", "pms", "PMS Colour Chart | Super Merch Australia", "Use the PMS colour chart when preparing artwork for custom branded merchandise."],
+};
+
+const cleanText = (value) =>
+  String(value || "")
+    .replace(/<[^>]*>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/\s+/g, " ")
+    .trim();
+
+const escapeHtml = (value) =>
+  String(value || "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+
+const fetchJson = async (url, timeoutMs = 8000) => {
+  const response = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
+  if (!response.ok) return null;
+  return response.json();
+};
+
+const fetchSeoOverride = async (entityType, entityId) => {
+  try {
+    const payload = await fetchJson(
+      `${BACKEND_URL}/api/seo-meta/by-entity/${encodeURIComponent(
+        entityType,
+      )}/${encodeURIComponent(String(entityId))}`,
+    );
+    return payload?.success && payload?.data ? payload.data : null;
+  } catch {
+    return null;
+  }
+};
+
+const resolvePage = async (path) => {
+  if (STATIC_PAGES[path]) {
+    const [entityType, entityId, title, description] = STATIC_PAGES[path];
+    return { entityType, entityId, title, description, image: DEFAULT_IMAGE };
+  }
+
+  const collectionMatch = path.match(/^\/collections\/([^/]+)$/);
+  if (collectionMatch) {
+    const slug = decodeURIComponent(collectionMatch[1]);
+    const payload = await fetchJson(
+      `${BACKEND_URL}/api/public/collection/${encodeURIComponent(slug)}?page=1&limit=1`,
+    );
+    const collection = payload?.collection || payload?.data?.collection;
+    if (!payload?.success || !collection) return null;
+    return {
+      entityType: "category",
+      entityId: `collection-${slug}`,
+      title: `${cleanText(collection.name)} | Super Merch Australia`,
+      description:
+        cleanText(collection.shortDescription).slice(0, 160) ||
+        `Browse products in our ${cleanText(collection.name)} collection.`,
+      image: cleanText(collection.image) || DEFAULT_IMAGE,
+    };
+  }
+
+  const dealMatch = path.match(/^\/deals\/([^/]+)$/);
+  if (dealMatch) {
+    const slug = decodeURIComponent(dealMatch[1]);
+    const payload = await fetchJson(
+      `${BACKEND_URL}/api/frontend/deal/${encodeURIComponent(slug)}`,
+    );
+    const deal = payload?.data;
+    if (!payload?.success || !deal) return null;
+    return {
+      entityType: "deal",
+      entityId: deal.id || deal._id || slug,
+      title: `${cleanText(deal.title)} Deal | Super Merch Australia`,
+      description:
+        cleanText(deal.description).slice(0, 160) ||
+        `Explore the ${cleanText(deal.title)} promotional product deal from Super Merch Australia.`,
+      image: cleanText(deal.bannerImage) || DEFAULT_IMAGE,
+    };
+  }
+
+  const blogMatch = path.match(/^\/blogs\/([^/]+)$/);
+  if (blogMatch) {
+    const id = decodeURIComponent(blogMatch[1]);
+    const payload = await fetchJson(
+      `${BACKEND_URL}/api/blogs/get-blog/${encodeURIComponent(id)}`,
+    );
+    const blog = payload?.blog || payload?.data;
+    if (!blog) return null;
+    const title = cleanText(blog.metaTitle || blog.title);
+    return {
+      entityType: "blog",
+      entityId: blog._id || id,
+      title: `${title} | Super Merch Australia`,
+      description:
+        cleanText(blog.metaDescription || blog.shortDescription || blog.content).slice(0, 160) ||
+        `Read ${title} from Super Merch Australia.`,
+      image:
+        cleanText(blog.ogImage || blog.image?.url || blog.image || blog.images?.[0]?.url) ||
+        DEFAULT_IMAGE,
+    };
+  }
+
+  const cmsMatch = path.match(/^\/page\/([^/]+)$/);
+  if (cmsMatch) {
+    const slug = decodeURIComponent(cmsMatch[1]);
+    const payload = await fetchJson(
+      `${BACKEND_URL}/api/cms-pages/by-slug/${encodeURIComponent(slug)}`,
+    );
+    const page = payload?.data || payload?.page;
+    if (!page) return null;
+    const title = cleanText(page.metaTitle || page.title || page.header);
+    return {
+      entityType: "cmsPage",
+      entityId: slug,
+      title: `${title} | Super Merch Australia`,
+      description:
+        cleanText(page.metaDescription || page.description || page.content).slice(0, 160) ||
+        `Learn more about ${title} from Super Merch Australia.`,
+      image: cleanText(page.ogImage || page.image) || DEFAULT_IMAGE,
+    };
+  }
+
+  return null;
+};
+
+const removeMeta = (html, key) => {
+  const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return html.replace(
+    new RegExp(
+      `<meta\\s+[^>]*(?:name|property)=["']${escaped}["'][^>]*>\\s*`,
+      "gi",
+    ),
+    "",
+  );
+};
+
+const injectHead = (html, tags) => {
+  const keys = [
+    "description",
+    "robots",
+    "og:title",
+    "og:description",
+    "og:image",
+    "og:image:alt",
+    "og:url",
+    "og:type",
+    "twitter:card",
+    "twitter:title",
+    "twitter:description",
+    "twitter:image",
+    "twitter:image:alt",
+    "twitter:url",
+  ];
+  let output = keys.reduce(removeMeta, html);
+  output = output.replace(/<title>[\s\S]*?<\/title>/i, "");
+  output = output.replace(/<link\s+[^>]*rel=["']canonical["'][^>]*>\s*/gi, "");
+  return output.replace("</head>", `${tags}\n</head>`);
+};
+
+export default async function handler(req, res) {
+  const rawPath = String(req.query.path || "/");
+  const path = rawPath.startsWith("/") ? rawPath : `/${rawPath}`;
+
+  let shell;
+  try {
+    const host = req.headers["x-forwarded-host"] || req.headers.host;
+    const protocol = host?.includes("localhost") ? "http" : "https";
+    const response = await fetch(`${protocol}://${host}/`, {
+      headers: { "x-seo-shell-request": "1" },
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!response.ok) throw new Error("Application shell unavailable");
+    shell = await response.text();
+  } catch {
+    res.status(503).send("Website temporarily unavailable");
+    return;
+  }
+
+  let page;
+  try {
+    page = await resolvePage(path);
+  } catch {
+    res.setHeader("Retry-After", "300");
+    res.status(503).send("Page data temporarily unavailable");
+    return;
+  }
+
+  if (!page) {
+    const title = "Page Not Found | Super Merch Australia";
+    const tags = `<title>${title}</title>
+<meta name="description" content="The requested page could not be found.">
+<meta name="robots" content="noindex, follow">`;
+    res.setHeader("Content-Type", "text/html; charset=utf-8");
+    res.status(404).send(injectHead(shell, tags));
+    return;
+  }
+
+  const override = await fetchSeoOverride(page.entityType, page.entityId);
+  const title = cleanText(override?.metaTitle) || page.title;
+  const description =
+    cleanText(override?.metaDescription).slice(0, 160) || page.description;
+  const socialTitle = cleanText(override?.ogTitle) || title;
+  const socialDescription =
+    cleanText(override?.ogDescription).slice(0, 200) || description;
+  const socialImage = cleanText(override?.ogImage) || page.image;
+  const canonical = `${SITE_URL}${path === "/" ? "/" : path.replace(/\/+$/, "")}`;
+
+  const tags = `<title>${escapeHtml(title)}</title>
+<meta name="description" content="${escapeHtml(description)}">
+<meta name="robots" content="index, follow">
+<link rel="canonical" href="${escapeHtml(canonical)}">
+<meta property="og:title" content="${escapeHtml(socialTitle)}">
+<meta property="og:description" content="${escapeHtml(socialDescription)}">
+<meta property="og:image" content="${escapeHtml(socialImage)}">
+<meta property="og:image:alt" content="${escapeHtml(title)}">
+<meta property="og:url" content="${escapeHtml(canonical)}">
+<meta property="og:type" content="website">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="${escapeHtml(socialTitle)}">
+<meta name="twitter:description" content="${escapeHtml(socialDescription)}">
+<meta name="twitter:image" content="${escapeHtml(socialImage)}">
+<meta name="twitter:image:alt" content="${escapeHtml(title)}">
+<meta name="twitter:url" content="${escapeHtml(canonical)}">`;
+
+  res.setHeader("Content-Type", "text/html; charset=utf-8");
+  res.setHeader("Cache-Control", "public, s-maxage=3600, stale-while-revalidate=86400");
+  res.status(200).send(injectHead(shell, tags));
+}

--- a/vercel.json
+++ b/vercel.json
@@ -5,6 +5,12 @@
     },
     "api/product-sitemap.js": {
       "maxDuration": 60
+    },
+    "api/content-sitemap.js": {
+      "maxDuration": 60
+    },
+    "api/seo-page.js": {
+      "maxDuration": 60
     }
   },
   "rewrites": [
@@ -17,12 +23,36 @@
       "destination": "/api/product-sitemap?page=:page"
     },
     {
+      "source": "/sitemap-static.xml",
+      "destination": "/api/content-sitemap"
+    },
+    {
       "source": "/product/:slug/:productId",
       "destination": "/api/product-page?slug=:slug&id=:productId"
     },
     {
       "source": "/product/:slug",
       "destination": "/api/product-page?slug=:slug"
+    },
+    {
+      "source": "/collections/:slug",
+      "destination": "/api/seo-page?path=/collections/:slug"
+    },
+    {
+      "source": "/deals/:slug",
+      "destination": "/api/seo-page?path=/deals/:slug"
+    },
+    {
+      "source": "/blogs/:id",
+      "destination": "/api/seo-page?path=/blogs/:id"
+    },
+    {
+      "source": "/page/:slug",
+      "destination": "/api/seo-page?path=/page/:slug"
+    },
+    {
+      "source": "/:path(home|shop|promotional|Clothing|Headwear|australia-made|24hr-production|return-gifts|deals|hot-deals|clearance|category|all-blogs|about|contact|faqs|artwork-policy|refund-policy|privacy|terms|help-center|pms)",
+      "destination": "/api/seo-page?path=/:path"
     },
     {
       "source": "/(.*)",


### PR DESCRIPTION
## What changed
- server-render metadata for indexable category and static pages
- server-render metadata for collections, deals, blogs and public CMS pages from their live backend records
- preserve `/seo-management` records as the highest-priority manual override layer
- return genuine 404 + `noindex, follow` HTML when a dynamic content record is missing
- replace the manually maintained static sitemap response with a live content sitemap containing active collections, published blogs and active deals
- enrich generated Product schema with authoritative category, material, colour and manufacturer-part-number fields
- improve the product meta-description fallback from live product attributes when supplier copy is absent

## Why
Product pages and product sitemap shards are already dynamic, but non-product metadata was primarily client-rendered and the static content sitemap required manual maintenance. This PR completes the dynamic SEO architecture without inventing availability, reviews, shipping or returns data.

## Safety
- search and private flows remain outside the server-rendered indexable route list
- existing SPA fallback remains unchanged
- existing product 404/410/503 behavior remains unchanged
- dynamic sitemap sources fail independently, so a temporary blog/deal/collection API failure does not take down the sitemap
- existing related-product linking, image lazy loading and Core Web Vitals changes are preserved

## Validation
- `npm run build` passed
- targeted ESLint passed for all three API handlers
- handler smoke tests passed for server-rendered metadata and dynamic collection/blog/deal sitemap URLs
- branch is four commits ahead of `bweb-dev` and zero behind

## Deployment verification
- confirm initial HTML metadata on `/shop`, `/collections/agriculture`, a live deal, a live blog and a CMS page
- confirm `/sitemap-static.xml` contains active collection, blog and deal URLs
- confirm `/sitemap.xml` still references the content sitemap plus all product shards
- validate representative Product JSON-LD in Schema.org and Google Rich Results Test