### PR TITLE
Fix category SEO lookup and duplicate product schema

### DIFF
--- a/api/product-page.js
+++ b/api/product-page.js
@@ -361,8 +361,8 @@ ${keywords ? `<meta name="keywords" content="${escapeHtml(keywords)}">` : ""}
 <meta name="twitter:image" content="${escapeHtml(socialImage)}">
 <meta name="twitter:image:alt" content="${escapeHtml(socialImageAlt)}">
 <meta name="twitter:url" content="${canonical}">
-<script type="application/ld+json">${escapeJson(productSchema)}</script>
-<script type="application/ld+json">${escapeJson(breadcrumbSchema)}</script>`;
+<script type="application/ld+json" data-sm-seo-jsonld="true">${escapeJson(productSchema)}</script>
+<script type="application/ld+json" data-sm-seo-jsonld="true">${escapeJson(breadcrumbSchema)}</script>`;
 
   res.setHeader("Content-Type", "text/html; charset=utf-8");
   res.setHeader("Cache-Control", "public, s-maxage=3600, stale-while-revalidate=86400");

--- a/api/seo-page.js
+++ b/api/seo-page.js
@@ -66,10 +66,20 @@ const fetchSeoOverride = async (entityType, entityId) => {
   }
 };
 
-const resolvePage = async (path) => {
+const resolvePage = async (path, category) => {
   if (STATIC_PAGES[path]) {
     const [entityType, entityId, title, description] = STATIC_PAGES[path];
-    return { entityType, entityId, title, description, image: DEFAULT_IMAGE };
+    return {
+      entityType,
+      entityId: path === "/shop" && category ? category : entityId,
+      title,
+      description,
+      image: DEFAULT_IMAGE,
+      canonicalPath:
+        path === "/shop" && category
+          ? `/shop?category=${encodeURIComponent(category)}`
+          : path,
+    };
   }
 
   const collectionMatch = path.match(/^\/collections\/([^/]+)$/);
@@ -192,6 +202,8 @@ const injectHead = (html, tags) => {
 export default async function handler(req, res) {
   const rawPath = String(req.query.path || "/");
   const path = rawPath.startsWith("/") ? rawPath : `/${rawPath}`;
+  const category =
+    path === "/shop" ? String(req.query.category || "").trim() : "";
 
   let shell;
   try {
@@ -210,7 +222,7 @@ export default async function handler(req, res) {
 
   let page;
   try {
-    page = await resolvePage(path);
+    page = await resolvePage(path, category);
   } catch {
     res.setHeader("Retry-After", "300");
     res.status(503).send("Page data temporarily unavailable");
@@ -235,7 +247,39 @@ export default async function handler(req, res) {
   const socialDescription =
     cleanText(override?.ogDescription).slice(0, 200) || description;
   const socialImage = cleanText(override?.ogImage) || page.image;
-  const canonical = `${SITE_URL}${path === "/" ? "/" : path.replace(/\/+$/, "")}`;
+  const fallbackCanonical = `${SITE_URL}${
+    page.canonicalPath === "/"
+      ? "/"
+      : page.canonicalPath.replace(/\/+$/, "")
+  }`;
+  const canonical = (() => {
+    try {
+      const parsed = new URL(
+        cleanText(override?.canonicalUrl) || fallbackCanonical,
+        SITE_URL,
+      );
+      parsed.protocol = "https:";
+      if (parsed.hostname === "supermerch.com.au") {
+        parsed.hostname = "www.supermerch.com.au";
+      }
+      [...parsed.searchParams.keys()].forEach((key) => {
+        const normalizedKey = key.toLowerCase();
+        if (
+          ["page", "sort", "view", "gclid", "fbclid"].includes(normalizedKey) ||
+          normalizedKey.startsWith("utm_")
+        ) {
+          parsed.searchParams.delete(key);
+        }
+      });
+      parsed.hash = "";
+      if (parsed.pathname.length > 1 && parsed.pathname.endsWith("/")) {
+        parsed.pathname = parsed.pathname.replace(/\/+$/, "");
+      }
+      return parsed.toString();
+    } catch {
+      return fallbackCanonical;
+    }
+  })();
 
   const tags = `<title>${escapeHtml(title)}</title>
 <meta name="description" content="${escapeHtml(description)}">

--- a/package.json
+++ b/package.json
@@ -62,6 +62,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.15.0",
+    "@testing-library/jest-dom": "^7.0.0",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^22.13.5",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
@@ -72,6 +74,7 @@
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.14",
     "globals": "^15.12.0",
+    "jsdom": "^29.1.1",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.17",
     "vite": "^6.0.1",

--- a/src/__tests__/ProductCard.discount.test.jsx
+++ b/src/__tests__/ProductCard.discount.test.jsx
@@ -1,12 +1,15 @@
+// @vitest-environment jsdom
+
 /**
  * Integration Test: Product Card Discount Display
  * Tests that discounts from backend are correctly displayed on product cards
  */
 
-import { render, screen } from '@testing-library/react';
+import { cleanup, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
 import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { afterEach, describe, it, expect, beforeEach } from 'vitest';
 import ProductCard from '../components/Common/ProductCard';
 import { store } from '../redux/store';
 
@@ -42,8 +45,18 @@ const createMockProduct = (discountInfo = null) => ({
     }
   },
   productTags: [],
-  discountInfo: discountInfo
+  discountInfo: discountInfo,
+  pricingSummary:
+    Number(discountInfo?.discount) > 0
+      ? {
+          finalMinPrice:
+            10 * (1 - Math.min(Number(discountInfo.discount), 100) / 100),
+          marginAdjustedMinPrice: 10,
+        }
+      : undefined,
 });
+
+afterEach(cleanup);
 
 describe('ProductCard Discount Display', () => {
   const renderProductCard = (product) => {

--- a/src/__tests__/dynamicSeo.test.js
+++ b/src/__tests__/dynamicSeo.test.js
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { toCanonicalUrl } from "../utils/canonicalUrl";
+import { getShopSeoContext } from "../utils/shopSeo";
+
+describe("dynamic category SEO", () => {
+  it("uses the selected category as the SEO entity", () => {
+    expect(getShopSeoContext("?category=wooden-pens")).toEqual({
+      entityId: "wooden-pens",
+      canonicalPath: "/shop?category=wooden-pens",
+    });
+  });
+
+  it("falls back to the general shop SEO record", () => {
+    expect(getShopSeoContext("")).toEqual({
+      entityId: "shop",
+      canonicalPath: "/shop",
+    });
+  });
+
+  it("keeps category while removing duplicate and tracking parameters", () => {
+    expect(
+      toCanonicalUrl(
+        "https://supermerch.com.au/shop?category=wooden-pens&page=2&sort=price&utm_source=test&gclid=1#products",
+      ),
+    ).toBe("https://www.supermerch.com.au/shop?category=wooden-pens");
+  });
+});
+

--- a/src/__tests__/seoPageHandler.test.js
+++ b/src/__tests__/seoPageHandler.test.js
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import handler from "../../api/seo-page";
+
+const response = (body, status = 200) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  json: async () => body,
+  text: async () => String(body),
+});
+
+const createResponse = () => {
+  const result = { headers: {}, statusCode: null, body: "" };
+  return {
+    result,
+    setHeader: (key, value) => {
+      result.headers[key] = value;
+    },
+    status: (statusCode) => {
+      result.statusCode = statusCode;
+      return {
+        send: (body) => {
+          result.body = body;
+        },
+      };
+    },
+  };
+};
+
+describe("SEO page handler", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders the selected category record and keeps only its canonical query", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        response("<html><head><title>Fallback</title></head><body></body></html>"),
+      )
+      .mockResolvedValueOnce(
+        response({
+          success: true,
+          data: {
+            metaTitle:
+              "Wooden Pens Promotional Products | Super Merch Australia",
+            canonicalUrl:
+              "https://supermerch.com.au/shop?category=wooden-pens&page=2&utm_source=test",
+          },
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+    const res = createResponse();
+
+    await handler(
+      {
+        query: {
+          path: "/shop",
+          category: "wooden-pens",
+          page: "2",
+        },
+        headers: { host: "www.supermerch.com.au" },
+      },
+      res,
+    );
+
+    expect(fetchMock.mock.calls[1][0]).toContain(
+      "/api/seo-meta/by-entity/category/wooden-pens",
+    );
+    expect(res.result.statusCode).toBe(200);
+    expect(res.result.body).toContain(
+      "<title>Wooden Pens Promotional Products | Super Merch Australia</title>",
+    );
+    expect(res.result.body).toContain(
+      '<link rel="canonical" href="https://www.supermerch.com.au/shop?category=wooden-pens">',
+    );
+  });
+});
+

--- a/src/components/Common/ProductCard.jsx
+++ b/src/components/Common/ProductCard.jsx
@@ -30,7 +30,10 @@ const ProductCard = ({ product, favSet = new Set(), onViewProduct, priority = fa
   // Use the admin-set clean value; fall back to rounded derived % only if no stored amount
   const discountPct = discountAmount > 0 ? discountAmount : Math.round(derivedDiscount);
   const isGlobalDiscount = product.discountInfo?.isGlobal || false;
-  const finalPrice = Number(product?.pricingSummary?.finalMinPrice) || getProductPrice(product, product.meta.id);
+  const summaryFinalPrice = Number(product?.pricingSummary?.finalMinPrice);
+  const finalPrice = Number.isFinite(summaryFinalPrice)
+    ? summaryFinalPrice
+    : getProductPrice(product, product.meta.id);
   const strikePrice = Number(product?.pricingSummary?.marginAdjustedMinPrice) || null;
   const handleRemoveFavourite = (product) => {
     toast.success("Product removed from favourites");

--- a/src/components/Common/RouteSeo.jsx
+++ b/src/components/Common/RouteSeo.jsx
@@ -1,5 +1,6 @@
 import { useLocation } from "react-router-dom";
 import SeoHelmet from "./SeoHelmet";
+import { getShopSeoContext } from "../../utils/shopSeo";
 
 const SITE_URL = "https://www.supermerch.com.au";
 const DEFAULT_IMAGE = `${SITE_URL}/logo-teal.png`;
@@ -19,6 +20,7 @@ const makeFallback = ({ title, description, keywords, path, ogType = "website" }
 const RouteSeo = () => {
   const location = useLocation();
   const pathname = location.pathname || "/";
+  const shopSeo = getShopSeoContext(location.search);
 
   if (
     pathname.startsWith("/product/") ||
@@ -68,12 +70,12 @@ const RouteSeo = () => {
   const staticSeoMap = {
     "/shop": {
       entityType: "category",
-      entityId: "shop",
+      entityId: shopSeo.entityId,
       fallback: makeFallback({
         title: "Shop Promotional Products | Super Merch Australia",
         description: "Browse branded promotional products, custom merchandise, and business giveaways.",
         keywords: "shop promotional products, branded merchandise australia, business giveaways",
-        path: "/shop",
+        path: shopSeo.canonicalPath,
       }),
     },
     "/about": {

--- a/src/components/Common/SeoHelmet.jsx
+++ b/src/components/Common/SeoHelmet.jsx
@@ -1,47 +1,7 @@
 import { useEffect } from "react";
 import PropTypes from "prop-types";
 import useSeoMeta from "../../hooks/useSeoMeta";
-
-const SITE_URL = "https://www.supermerch.com.au";
-
-/**
- * Force every canonical / og:url onto the one canonical host.
- *
- * The site is served from www.supermerch.com.au and the apex domain only
- * redirects to it. A canonical pointing at the apex tells Google to index a
- * URL that redirects, which is what caused the July 2026 indexing failure.
- * Many seo-meta records still store apex URLs, so we normalise here rather
- * than trusting the stored value.
- */
-const toCanonicalUrl = (value, pathname) => {
-  const path =
-    pathname ||
-    (typeof window !== "undefined" ? window.location.pathname : "/");
-
-  let url =
-    value && String(value).trim() ? String(value).trim() : `${SITE_URL}${path}`;
-
-  // Make relative values absolute.
-  if (url.startsWith("/")) url = `${SITE_URL}${url}`;
-
-  try {
-    const parsed = new URL(url);
-    parsed.protocol = "https:";
-    if (parsed.hostname === "supermerch.com.au") {
-      parsed.hostname = "www.supermerch.com.au";
-    }
-    // Canonicals should be clean: no query string, no fragment.
-    parsed.search = "";
-    parsed.hash = "";
-    // Strip a trailing slash except on the root.
-    if (parsed.pathname.length > 1 && parsed.pathname.endsWith("/")) {
-      parsed.pathname = parsed.pathname.replace(/\/+$/, "");
-    }
-    return parsed.toString();
-  } catch {
-    return `${SITE_URL}${path}`;
-  }
-};
+import { toCanonicalUrl } from "../../utils/canonicalUrl";
 
 /**
  * Create or update a meta tag.

--- a/src/utils/canonicalUrl.js
+++ b/src/utils/canonicalUrl.js
@@ -1,0 +1,41 @@
+const SITE_URL = "https://www.supermerch.com.au";
+const REMOVED_QUERY_PARAMS = new Set([
+  "page",
+  "sort",
+  "view",
+  "gclid",
+  "fbclid",
+]);
+
+export const toCanonicalUrl = (value, pathname) => {
+  const path =
+    pathname ||
+    (typeof window !== "undefined" ? window.location.pathname : "/");
+  const url =
+    value && String(value).trim() ? String(value).trim() : `${SITE_URL}${path}`;
+
+  try {
+    const parsed = new URL(url, SITE_URL);
+    parsed.protocol = "https:";
+    if (parsed.hostname === "supermerch.com.au") {
+      parsed.hostname = "www.supermerch.com.au";
+    }
+    [...parsed.searchParams.keys()].forEach((key) => {
+      const normalizedKey = key.toLowerCase();
+      if (
+        REMOVED_QUERY_PARAMS.has(normalizedKey) ||
+        normalizedKey.startsWith("utm_")
+      ) {
+        parsed.searchParams.delete(key);
+      }
+    });
+    parsed.hash = "";
+    if (parsed.pathname.length > 1 && parsed.pathname.endsWith("/")) {
+      parsed.pathname = parsed.pathname.replace(/\/+$/, "");
+    }
+    return parsed.toString();
+  } catch {
+    return `${SITE_URL}${path}`;
+  }
+};
+

--- a/src/utils/shopSeo.js
+++ b/src/utils/shopSeo.js
@@ -1,0 +1,12 @@
+export const getShopSeoContext = (search = "") => {
+  const params = new URLSearchParams(search);
+  const category = params.get("category")?.trim() || "";
+
+  return {
+    entityId: category || "shop",
+    canonicalPath: category
+      ? `/shop?category=${encodeURIComponent(category)}`
+      : "/shop",
+  };
+};
+

--- a/src/utils/utils.jsx
+++ b/src/utils/utils.jsx
@@ -8,7 +8,8 @@ export const getProductPrice = (product, id,isClothing) => {
 
   const priceGroups = product?.product?.prices?.price_groups || [];
   const basePrice = priceGroups.find((group) => group?.base_price) || {};
-  const additionalPrice = priceGroups.find((group) => group?.additions.length>0) || {};
+  const additionalPrice =
+    priceGroups.find((group) => group?.additions?.length > 0) || {};
   const firstPrintPrice = additionalPrice?.additions?.[0]?.price_breaks
   const priceBreaks = basePrice.base_price?.price_breaks || [];
   const prices = priceBreaks


### PR DESCRIPTION
## What changed
- use the active `/shop?category=` value as the category SEO entity ID, falling back to `shop`
- preserve `category` in canonicals while removing `page`, `sort`, `view`, `utm_*`, `gclid` and `fbclid`
- apply the same database-first metadata and canonical behavior in server-rendered HTML
- mark edge-rendered product JSON-LD so the client replaces it instead of duplicating it
- add the missing React DOM testing dependencies and activate the existing discount-card integration suite
- fix two price edge cases exposed by that suite: absent additions arrays and legitimate zero-dollar final prices
- add focused regression tests for category lookup, canonical cleaning and server-rendered metadata

## Source of truth
Existing database SEO records remain the highest-priority source. Hardcoded metadata remains only as a fallback.

## Validation
- complete test suite passed: 46/46
- production build passed
- targeted SEO lint passed
- `git diff --check` passed

## Acceptance coverage
- `wooden-pens` requests `category/wooden-pens`
- canonical keeps `category=wooden-pens` and drops pagination/tracking parameters
- no category uses `category/shop`
- hydrated product pages retain one Product and one BreadcrumbList block