### PR TITLE
Canonicalise unknown shop categories to shop

### DIFF
--- a/api/seo-page.js
+++ b/api/seo-page.js
@@ -247,10 +247,12 @@ export default async function handler(req, res) {
   const socialDescription =
     cleanText(override?.ogDescription).slice(0, 200) || description;
   const socialImage = cleanText(override?.ogImage) || page.image;
+  const canonicalPath =
+    path === "/shop" && category && !override ? "/shop" : page.canonicalPath;
   const fallbackCanonical = `${SITE_URL}${
-    page.canonicalPath === "/"
+    canonicalPath === "/"
       ? "/"
-      : page.canonicalPath.replace(/\/+$/, "")
+      : canonicalPath.replace(/\/+$/, "")
   }`;
   const canonical = (() => {
     try {

--- a/src/__tests__/seoPageHandler.test.js
+++ b/src/__tests__/seoPageHandler.test.js
@@ -74,5 +74,31 @@ describe("SEO page handler", () => {
       '<link rel="canonical" href="https://www.supermerch.com.au/shop?category=wooden-pens">',
     );
   });
-});
 
+  it("canonicalises an unknown category to the general shop", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        response("<html><head><title>Fallback</title></head><body></body></html>"),
+      )
+      .mockResolvedValueOnce(response({ success: false }, 404));
+    vi.stubGlobal("fetch", fetchMock);
+    const res = createResponse();
+
+    await handler(
+      {
+        query: {
+          path: "/shop",
+          category: "does-not-exist-xyz",
+        },
+        headers: { host: "www.supermerch.com.au" },
+      },
+      res,
+    );
+
+    expect(res.result.statusCode).toBe(200);
+    expect(res.result.body).toContain(
+      '<link rel="canonical" href="https://www.supermerch.com.au/shop">',
+    );
+  });
+});

--- a/src/components/Common/RouteSeo.jsx
+++ b/src/components/Common/RouteSeo.jsx
@@ -71,6 +71,8 @@ const RouteSeo = () => {
     "/shop": {
       entityType: "category",
       entityId: shopSeo.entityId,
+      canonicalUrlWhenSeoMissing:
+        shopSeo.entityId === "shop" ? undefined : `${SITE_URL}/shop`,
       fallback: makeFallback({
         title: "Shop Promotional Products | Super Merch Australia",
         description: "Browse branded promotional products, custom merchandise, and business giveaways.",
@@ -422,6 +424,7 @@ const RouteSeo = () => {
         entityType={seo.entityType}
         entityId={seo.entityId}
         fallback={seo.fallback}
+        canonicalUrlWhenSeoMissing={seo.canonicalUrlWhenSeoMissing}
       />
     );
   }

--- a/src/components/Common/SeoHelmet.jsx
+++ b/src/components/Common/SeoHelmet.jsx
@@ -65,8 +65,9 @@ const SeoHelmet = ({
   fallback = {},
   structuredData = [],
   forceCanonicalUrl,
+  canonicalUrlWhenSeoMissing,
 }) => {
-  const { seoData } = useSeoMeta(entityType, entityId);
+  const { seoData, resolved } = useSeoMeta(entityType, entityId);
 
   const title = seoData?.metaTitle || fallback.title || "";
   const description = seoData?.metaDescription || fallback.description || "";
@@ -79,7 +80,10 @@ const SeoHelmet = ({
   const siteName = fallback.siteName || "Super Merch";
   const robots = fallback.robots || "index, follow";
   const canonical = toCanonicalUrl(
-    forceCanonicalUrl || seoData?.canonicalUrl || fallback.canonicalUrl
+    forceCanonicalUrl ||
+      seoData?.canonicalUrl ||
+      (resolved && !seoData ? canonicalUrlWhenSeoMissing : "") ||
+      fallback.canonicalUrl
   );
 
   useEffect(() => {
@@ -142,6 +146,7 @@ SeoHelmet.propTypes = {
   fallback: PropTypes.object,
   structuredData: PropTypes.arrayOf(PropTypes.object),
   forceCanonicalUrl: PropTypes.string,
+  canonicalUrlWhenSeoMissing: PropTypes.string,
 };
 
 export default SeoHelmet;

--- a/src/hooks/useSeoMeta.js
+++ b/src/hooks/useSeoMeta.js
@@ -9,6 +9,7 @@ const seoCache = new Map();
 export default function useSeoMeta(entityType, entityId) {
   const [seoData, setSeoData] = useState(null);
   const [loading, setLoading] = useState(false);
+  const [resolved, setResolved] = useState(false);
 
   useEffect(() => {
     if (!backendUrl || !entityType || !entityId) return;
@@ -20,6 +21,7 @@ export default function useSeoMeta(entityType, entityId) {
 
     if (seoCache.has(cacheKey)) {
       setSeoData(seoCache.get(cacheKey));
+      setResolved(true);
       return;
     }
 
@@ -27,6 +29,7 @@ export default function useSeoMeta(entityType, entityId) {
     // Do not briefly apply the previous entity's manual overrides while the
     // newly resolved product ID is loading.
     setSeoData(null);
+    setResolved(false);
     setLoading(true);
 
     axios
@@ -35,13 +38,18 @@ export default function useSeoMeta(entityType, entityId) {
         if (!cancelled && res.data?.success && res.data?.data) {
           seoCache.set(cacheKey, res.data.data);
           setSeoData(res.data.data);
+        } else if (!cancelled) {
+          seoCache.set(cacheKey, null);
         }
       })
       .catch(() => {
         // Graceful fallback — no SEO data is fine
       })
       .finally(() => {
-        if (!cancelled) setLoading(false);
+        if (!cancelled) {
+          setLoading(false);
+          setResolved(true);
+        }
       });
 
     return () => {
@@ -49,5 +57,5 @@ export default function useSeoMeta(entityType, entityId) {
     };
   }, [entityType, entityId]);
 
-  return { seoData, loading };
+  return { seoData, loading, resolved };
 }


### PR DESCRIPTION
## What changed
- track whether a category SEO lookup has resolved
- retain the category canonical only when a matching database SEO record exists
- fall back unknown category parameters to `https://www.supermerch.com.au/shop` in both initial HTML and the hydrated app
- cache confirmed missing records to avoid repeat lookups
- add an unknown-category server-rendering regression test

## Safety
Valid database-managed category records remain the source of truth and keep their category canonicals.

## Validation
- complete suite: 47/47 tests passed
- production build passed
- targeted ESLint passed
- `git diff --check` passed