### PR TITLE
Add reusable Bottle Finder pilot

### DIFF
--- a/src/__tests__/categoryFinderConfig.test.js
+++ b/src/__tests__/categoryFinderConfig.test.js
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import {
+  CATEGORY_FINDER_CONFIG,
+  getCategoryFinderConfig,
+} from "../config/categoryFinderConfig";
+
+describe("categoryFinderConfig", () => {
+  it("enables the pilot only for drink bottles", () => {
+    expect(getCategoryFinderConfig("PE-02")).toBe(
+      CATEGORY_FINDER_CONFIG["PE-02"]
+    );
+    expect(getCategoryFinderConfig("PA-01")).toBeNull();
+    expect(getCategoryFinderConfig(null)).toBeNull();
+  });
+
+  it("uses unique question identifiers and supported mappings", () => {
+    const config = getCategoryFinderConfig("PE-02");
+    const ids = config.questions.map((question) => question.id);
+
+    expect(new Set(ids).size).toBe(ids.length);
+    config.questions.forEach((question) => {
+      expect(question.options.length).toBeGreaterThan(0);
+      expect(["query", "attribute", "price"]).toContain(question.type);
+      if (question.type === "query") {
+        expect(question.queryParam).toBeTruthy();
+      }
+      if (question.type === "attribute") {
+        expect(question.attributeName).toBeTruthy();
+      }
+    });
+  });
+});

--- a/src/components/shop/Cards.jsx
+++ b/src/components/shop/Cards.jsx
@@ -1,5 +1,6 @@
 import { setMaxPrice, setMinPrice, setMoq } from "@/redux/slices/filterSlice";
-import { slugify, toProductUrl } from "@/utils/utils";
+import { toProductUrl } from "@/utils/utils";
+import PropTypes from "prop-types";
 import { useContext, useEffect, useRef, useState } from "react";
 import { IoIosArrowDown, IoIosArrowUp } from "react-icons/io";
 import { useDispatch, useSelector } from "react-redux";
@@ -12,6 +13,7 @@ import EmptyState from "../Common/EmptyState";
 import ProductCard from "../Common/ProductCard";
 import SkeletonLoadingCards from "../Common/SkeletonLoadingCards";
 import UnifiedSidebar from "../shared/UnifiedSidebar";
+import CategoryFinder from "./CategoryFinder";
 const Cards = ({ category = "" }) => {
 
   const location = useLocation();
@@ -595,6 +597,7 @@ const Cards = ({ category = "" }) => {
         </div>
 
         <div className="flex-1 w-full lg:mt-0 md:mt-4 mt-0">
+          <CategoryFinder productTypeId={urlCategoryParam} />
           <div className="lg:hidden">
             <div className="flex items-center justify-between w-full mb-4">
               <button
@@ -848,6 +851,10 @@ const Cards = ({ category = "" }) => {
       </div>
     </>
   );
+};
+
+Cards.propTypes = {
+  category: PropTypes.string,
 };
 
 export default Cards;

--- a/src/components/shop/CategoryFinder.jsx
+++ b/src/components/shop/CategoryFinder.jsx
@@ -1,0 +1,203 @@
+import { getCategoryFinderConfig } from "@/config/categoryFinderConfig";
+import { Search, SlidersHorizontal, X } from "lucide-react";
+import PropTypes from "prop-types";
+import { useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+
+const getAttributeSelections = (searchParams) => {
+  const names = searchParams.getAll("attrName");
+  const values = searchParams.getAll("attrValue");
+  return names.reduce((result, name, index) => {
+    result[name] = values[index] || "";
+    return result;
+  }, {});
+};
+
+const readSelections = (config, searchParams) => {
+  const attributes = getAttributeSelections(searchParams);
+  return config.questions.reduce((result, question) => {
+    if (question.type === "attribute") {
+      result[question.id] = attributes[question.attributeName] || "";
+    } else if (question.type === "price") {
+      const min = searchParams.get("minPrice") || "";
+      const max = searchParams.get("maxPrice") || "";
+      result[question.id] = min || max ? `${min}:${max}` : "";
+    } else {
+      result[question.id] = searchParams.get(question.queryParam) || "";
+    }
+    return result;
+  }, {});
+};
+
+const CategoryFinder = ({ productTypeId }) => {
+  const config = useMemo(
+    () => getCategoryFinderConfig(productTypeId),
+    [productTypeId]
+  );
+  const [searchParams, setSearchParams] = useSearchParams();
+  const searchParamsKey = searchParams.toString();
+  const [selections, setSelections] = useState(() =>
+    config ? readSelections(config, searchParams) : {}
+  );
+
+  useEffect(() => {
+    if (config) {
+      setSelections(readSelections(config, new URLSearchParams(searchParamsKey)));
+    }
+  }, [config, searchParamsKey]);
+
+  if (!config) return null;
+
+  const selectedCount = Object.values(selections).filter(Boolean).length;
+
+  const applyFinder = () => {
+    const next = new URLSearchParams(searchParams);
+    const existingAttributes = getAttributeSelections(next);
+
+    config.questions.forEach((question) => {
+      const value = selections[question.id] || "";
+
+      if (question.type === "attribute") {
+        if (value) existingAttributes[question.attributeName] = value;
+        else delete existingAttributes[question.attributeName];
+      } else if (question.type === "price") {
+        next.delete("minPrice");
+        next.delete("maxPrice");
+        if (value) {
+          const [min, max] = value.split(":");
+          if (min) next.set("minPrice", min);
+          if (max) next.set("maxPrice", max);
+        }
+      } else if (value) {
+        next.set(question.queryParam, value);
+      } else {
+        next.delete(question.queryParam);
+      }
+    });
+
+    next.delete("attrName");
+    next.delete("attrValue");
+    Object.entries(existingAttributes).forEach(([name, value]) => {
+      if (!value) return;
+      next.append("attrName", name);
+      next.append("attrValue", value);
+    });
+    next.set("page", "1");
+    next.delete("scrollTo");
+    setSearchParams(next);
+  };
+
+  const clearFinder = () => {
+    const next = new URLSearchParams(searchParams);
+    config.questions.forEach((question) => {
+      if (question.type === "attribute") return;
+      if (question.type === "price") {
+        next.delete("minPrice");
+        next.delete("maxPrice");
+      } else {
+        next.delete(question.queryParam);
+      }
+    });
+
+    const finderAttributeNames = new Set(
+      config.questions
+        .filter((question) => question.type === "attribute")
+        .map((question) => question.attributeName)
+    );
+    const attributes = getAttributeSelections(next);
+    next.delete("attrName");
+    next.delete("attrValue");
+    Object.entries(attributes).forEach(([name, value]) => {
+      if (!finderAttributeNames.has(name) && value) {
+        next.append("attrName", name);
+        next.append("attrValue", value);
+      }
+    });
+    next.set("page", "1");
+    next.delete("scrollTo");
+    setSelections(readSelections(config, new URLSearchParams()));
+    setSearchParams(next);
+  };
+
+  return (
+    <section className="mb-5 overflow-hidden rounded-2xl border border-[#d9e7ff] bg-gradient-to-br from-white via-[#f7faff] to-[#eef5ff] shadow-sm">
+      <div className="grid gap-5 p-4 sm:p-5 lg:grid-cols-[minmax(190px,0.72fr)_minmax(0,2.28fr)] lg:items-end lg:p-6">
+        <div>
+          <div className="mb-2 inline-flex items-center gap-2 rounded-full bg-primary/10 px-3 py-1 text-xs font-bold uppercase tracking-[0.12em] text-primary">
+            <SlidersHorizontal className="h-3.5 w-3.5" />
+            {config.eyebrow}
+          </div>
+          <h2 className="text-xl font-bold leading-tight text-gray-950 sm:text-2xl">
+            {config.title}
+          </h2>
+          <p className="mt-2 max-w-xl text-sm leading-5 text-gray-600">
+            {config.description}
+          </p>
+        </div>
+
+        <div>
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
+            {config.questions.map((question) => (
+              <label key={question.id} className="block">
+                <span className="mb-1.5 block text-xs font-semibold text-gray-700">
+                  {question.label}
+                </span>
+                <select
+                  value={selections[question.id] || ""}
+                  onChange={(event) =>
+                    setSelections((current) => ({
+                      ...current,
+                      [question.id]: event.target.value,
+                    }))
+                  }
+                  className="h-11 w-full rounded-lg border border-gray-300 bg-white px-3 text-sm text-gray-900 outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/15"
+                >
+                  <option value="">{question.placeholder}</option>
+                  {question.options.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            ))}
+          </div>
+
+          <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-xs text-gray-500">
+              {selectedCount
+                ? `${selectedCount} preference${selectedCount === 1 ? "" : "s"} selected`
+                : "Choose one or more preferences, or continue with all bottles."}
+            </p>
+            <div className="flex flex-col gap-2 sm:flex-row">
+              {selectedCount > 0 && (
+                <button
+                  type="button"
+                  onClick={clearFinder}
+                  className="inline-flex h-11 items-center justify-center gap-2 rounded-lg border border-gray-300 bg-white px-4 text-sm font-semibold text-gray-700 transition hover:bg-gray-50"
+                >
+                  <X className="h-4 w-4" />
+                  Clear
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={applyFinder}
+                className="inline-flex h-11 items-center justify-center gap-2 rounded-lg bg-primary px-5 text-sm font-semibold text-white shadow-sm transition hover:bg-primary/90"
+              >
+                <Search className="h-4 w-4" />
+                {selectedCount ? config.submitLabel : "View all bottles"}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+CategoryFinder.propTypes = {
+  productTypeId: PropTypes.string,
+};
+
+export default CategoryFinder;

--- a/src/config/categoryFinderConfig.js
+++ b/src/config/categoryFinderConfig.js
@@ -1,0 +1,87 @@
+export const CATEGORY_FINDER_CONFIG = {
+  "PE-02": {
+    eyebrow: "Bottle Finder",
+    title: "Find the right bottle in under 30 seconds",
+    description:
+      "Choose what matters most and we’ll narrow the range. You can change or remove any filter afterwards.",
+    submitLabel: "Show my matches",
+    questions: [
+      {
+        id: "moq",
+        label: "Order quantity",
+        placeholder: "Any quantity",
+        type: "query",
+        queryParam: "moq",
+        options: [
+          { label: "1–24", value: "24" },
+          { label: "25–49", value: "49" },
+          { label: "50–99", value: "99" },
+          { label: "100–249", value: "249" },
+          { label: "250–499", value: "499" },
+          { label: "500+", value: "500" },
+        ],
+      },
+      {
+        id: "capacity",
+        label: "Capacity",
+        placeholder: "Any size",
+        type: "attribute",
+        attributeName: "Capacity",
+        options: [
+          { label: "Under 300ml", value: "100ml - 199ml,200ml - 299ml" },
+          { label: "300–499ml", value: "300ml - 499ml" },
+          { label: "500–749ml", value: "500ml - 749ml" },
+          { label: "750–999ml", value: "750ml - 999ml" },
+          { label: "1 litre+", value: "1000lm - 1999ml,2 - 4.9 Litres,5 - 9.9 Litres" },
+        ],
+      },
+      {
+        id: "material",
+        label: "Bottle type",
+        placeholder: "Any material",
+        type: "attribute",
+        attributeName: "Material",
+        options: [
+          { label: "Stainless steel", value: "Stainless Steel" },
+          { label: "Aluminium", value: "Aluminium" },
+          { label: "Tritan plastic", value: "Triton Plastic" },
+          { label: "Other plastic", value: "Polyethylene,Polypropylene,rPET" },
+          { label: "Glass", value: "Glass" },
+          { label: "Eco materials", value: "Bamboo,Wheat Straw,Cork,rPET" },
+        ],
+      },
+      {
+        id: "colour",
+        label: "Colour",
+        placeholder: "Any colour",
+        type: "query",
+        queryParam: "colors",
+        options: [
+          { label: "Black", value: "Black" },
+          { label: "White", value: "White" },
+          { label: "Blue", value: "Blue" },
+          { label: "Red", value: "Red" },
+          { label: "Green", value: "Green" },
+          { label: "Silver", value: "Silver" },
+          { label: "Natural", value: "Natural" },
+        ],
+      },
+      {
+        id: "budget",
+        label: "Unit budget (ex GST)",
+        placeholder: "Any budget",
+        type: "price",
+        options: [
+          { label: "Under $5", value: "0:5" },
+          { label: "$5–$10", value: "5:10" },
+          { label: "$10–$20", value: "10:20" },
+          { label: "$20–$35", value: "20:35" },
+          { label: "$35+", value: "35:" },
+        ],
+      },
+    ],
+  },
+};
+
+export const getCategoryFinderConfig = (productTypeId) =>
+  CATEGORY_FINDER_CONFIG[productTypeId] || null;


### PR DESCRIPTION
## What

- add a guided “Find the right bottle” experience for Drink Bottles (PE-02)
- map answers to the catalogue’s existing URL filters for MOQ, capacity, material, colour, and unit budget
- introduce a reusable category configuration so future categories can define different questions
- add focused configuration tests

## Why

The Drink Bottles category currently returns hundreds of records. This pilot helps customers narrow the catalogue before browsing while preserving shareable filter URLs and the existing product-results flow.

## Impact

Only the Drink Bottles category (PE-02) is enabled. Other categories continue to render as before.

Delivery-time and branding-method questions are intentionally excluded from this pilot because those filters are not reliably supported by the current catalogue API/data.

## Checks

- `npm test -- --run src/__tests__/categoryFinderConfig.test.js`
- `npx eslint src/components/shop/CategoryFinder.jsx src/config/categoryFinderConfig.js src/__tests__/categoryFinderConfig.test.js src/components/shop/Cards.jsx --quiet`
- `npm run build`
- `git diff --check`

The full-repository lint still contains pre-existing failures outside this change.