### PR TITLE
Expand the guided Finder across catalogue categories

### DIFF
--- a/src/__tests__/categoryFinderConfig.test.js
+++ b/src/__tests__/categoryFinderConfig.test.js
@@ -41,6 +41,7 @@ describe("categoryFinderConfig", () => {
     const ids = config.questions.map((question) => question.id);
 
     expect(new Set(ids).size).toBe(ids.length);
+    expect(ids.slice(0, 2)).toEqual(["moq", "budget"]);
     config.questions.forEach((question) => {
       expect(question.options.length).toBeGreaterThan(0);
       expect(["query", "attribute", "price"]).toContain(question.type);

--- a/src/__tests__/categoryFinderConfig.test.js
+++ b/src/__tests__/categoryFinderConfig.test.js
@@ -5,12 +5,35 @@ import {
 } from "../config/categoryFinderConfig";
 
 describe("categoryFinderConfig", () => {
-  it("enables the pilot only for drink bottles", () => {
+  it("keeps the curated drink-bottle configuration", () => {
     expect(getCategoryFinderConfig("PE-02")).toBe(
       CATEGORY_FINDER_CONFIG["PE-02"]
     );
-    expect(getCategoryFinderConfig("PA-01")).toBeNull();
     expect(getCategoryFinderConfig(null)).toBeNull();
+  });
+
+  it("builds category-specific questions from reliable API attributes", () => {
+    const config = getCategoryFinderConfig("PM-04", {
+      categoryLabel: "Candles",
+      attributes: [
+        { name: "Eco Factors", values: ["Natural Material", "Recycled"] },
+        { name: "Material", values: ["Glass", "Ceramic"] },
+      ],
+    });
+
+    expect(config.title).toContain("candles");
+    expect(config.questions.map((question) => question.attributeName)).toEqual(
+      expect.arrayContaining(["Material", "Eco Factors"])
+    );
+  });
+
+  it("does not display a generic Finder without structured attributes", () => {
+    expect(
+      getCategoryFinderConfig("PM-04", {
+        categoryLabel: "Candles",
+        attributes: [],
+      })
+    ).toBeNull();
   });
 
   it("uses unique question identifiers and supported mappings", () => {

--- a/src/components/shop/Cards.jsx
+++ b/src/components/shop/Cards.jsx
@@ -597,7 +597,15 @@ const Cards = ({ category = "" }) => {
         </div>
 
         <div className="flex-1 w-full lg:mt-0 md:mt-4 mt-0">
-          <CategoryFinder productTypeId={urlCategoryParam} />
+          <CategoryFinder
+            attributes={isProductsLoading ? [] : getProducts?.attributes}
+            categoryLabel={
+              searchParams.get("subCategory") ||
+              searchParams.get("categoryName") ||
+              ""
+            }
+            productTypeId={urlCategoryParam}
+          />
           <div className="lg:hidden">
             <div className="flex items-center justify-between w-full mb-4">
               <button

--- a/src/components/shop/CategoryFinder.jsx
+++ b/src/components/shop/CategoryFinder.jsx
@@ -29,10 +29,14 @@ const readSelections = (config, searchParams) => {
   }, {});
 };
 
-const CategoryFinder = ({ productTypeId }) => {
+const CategoryFinder = ({ attributes = [], categoryLabel = "", productTypeId }) => {
   const config = useMemo(
-    () => getCategoryFinderConfig(productTypeId),
-    [productTypeId]
+    () =>
+      getCategoryFinderConfig(productTypeId, {
+        attributes,
+        categoryLabel,
+      }),
+    [attributes, categoryLabel, productTypeId]
   );
   const [searchParams, setSearchParams] = useSearchParams();
   const searchParamsKey = searchParams.toString();
@@ -167,7 +171,7 @@ const CategoryFinder = ({ productTypeId }) => {
             <p className="text-xs text-gray-500">
               {selectedCount
                 ? `${selectedCount} preference${selectedCount === 1 ? "" : "s"} selected`
-                : "Choose one or more preferences, or continue with all bottles."}
+                : "Choose one or more preferences, or continue with all products."}
             </p>
             <div className="flex flex-col gap-2 sm:flex-row">
               {selectedCount > 0 && (
@@ -186,7 +190,9 @@ const CategoryFinder = ({ productTypeId }) => {
                 className="inline-flex h-11 items-center justify-center gap-2 rounded-lg bg-primary px-5 text-sm font-semibold text-white shadow-sm transition hover:bg-primary/90"
               >
                 <Search className="h-4 w-4" />
-                {selectedCount ? config.submitLabel : "View all bottles"}
+                {selectedCount
+                  ? config.submitLabel
+                  : config.emptySubmitLabel || "View all bottles"}
               </button>
             </div>
           </div>
@@ -197,6 +203,13 @@ const CategoryFinder = ({ productTypeId }) => {
 };
 
 CategoryFinder.propTypes = {
+  attributes: PropTypes.arrayOf(
+    PropTypes.shape({
+      name: PropTypes.string,
+      values: PropTypes.arrayOf(PropTypes.string),
+    })
+  ),
+  categoryLabel: PropTypes.string,
   productTypeId: PropTypes.string,
 };
 

--- a/src/config/categoryFinderConfig.js
+++ b/src/config/categoryFinderConfig.js
@@ -124,6 +124,7 @@ export const CATEGORY_FINDER_CONFIG = {
     submitLabel: "Show my matches",
     questions: [
       ORDER_QUANTITY_QUESTION,
+      BUDGET_QUESTION,
       {
         id: "capacity",
         label: "Capacity",
@@ -154,7 +155,6 @@ export const CATEGORY_FINDER_CONFIG = {
         ],
       },
       COLOUR_QUESTION,
-      BUDGET_QUESTION,
     ],
   },
 };
@@ -186,9 +186,9 @@ export const getCategoryFinderConfig = (
     emptySubmitLabel: `View all ${labelLower}`,
     questions: [
       ORDER_QUANTITY_QUESTION,
+      BUDGET_QUESTION,
       ...attributeQuestions,
       COLOUR_QUESTION,
-      BUDGET_QUESTION,
     ],
   };
 };

--- a/src/config/categoryFinderConfig.js
+++ b/src/config/categoryFinderConfig.js
@@ -1,3 +1,120 @@
+const ORDER_QUANTITY_QUESTION = {
+  id: "moq",
+  label: "Order quantity",
+  placeholder: "Any quantity",
+  type: "query",
+  queryParam: "moq",
+  options: [
+    { label: "1–24", value: "24" },
+    { label: "25–49", value: "49" },
+    { label: "50–99", value: "99" },
+    { label: "100–249", value: "249" },
+    { label: "250–499", value: "499" },
+    { label: "500+", value: "500" },
+  ],
+};
+
+const COLOUR_QUESTION = {
+  id: "colour",
+  label: "Colour",
+  placeholder: "Any colour",
+  type: "query",
+  queryParam: "colors",
+  options: [
+    { label: "Black", value: "Black" },
+    { label: "White", value: "White" },
+    { label: "Blue", value: "Blue" },
+    { label: "Red", value: "Red" },
+    { label: "Green", value: "Green" },
+    { label: "Silver", value: "Silver" },
+    { label: "Natural", value: "Natural" },
+  ],
+};
+
+const BUDGET_QUESTION = {
+  id: "budget",
+  label: "Unit budget (ex GST)",
+  placeholder: "Any budget",
+  type: "price",
+  options: [
+    { label: "Under $5", value: "0:5" },
+    { label: "$5–$10", value: "5:10" },
+    { label: "$10–$20", value: "10:20" },
+    { label: "$20–$35", value: "20:35" },
+    { label: "$35+", value: "35:" },
+  ],
+};
+
+const ATTRIBUTE_PRIORITY_BY_GROUP = {
+  PA: ["Features", "Material", "Capacity", "Eco Factors"],
+  PB: ["Material", "Features", "Eco Factors"],
+  PC: ["Material", "Features", "Eco Factors"],
+  PD: ["Features", "Eco Factors", "Material"],
+  PE: ["Capacity", "Features", "Material", "Eco Factors"],
+  PF: ["Features", "Material", "Eco Factors"],
+  PG: ["Material", "Features", "Sport"],
+  PH: ["Features", "Material", "Sport"],
+  PI: ["Capacity", "Material", "Features"],
+  PJ: ["Features", "Material", "Sport"],
+  PK: ["Material", "Features", "Eco Factors"],
+  PL: ["Features", "Material", "Eco Factors"],
+  PM: ["Features", "Material", "Eco Factors"],
+  PN: ["Material", "Features", "Eco Factors"],
+  PO: ["Material", "Features", "Eco Factors"],
+  PP: ["Features", "Material", "Eco Factors"],
+  PQ: ["Features", "Material", "Sport", "Eco Factors"],
+  PR: ["Features", "Material", "Eco Factors"],
+  PS: ["Features", "Capacity", "Material", "Eco Factors"],
+  PT: ["Material", "Features", "Eco Factors"],
+  PU: ["Material", "Features", "Eco Factors"],
+  PV: ["Sport", "Material", "Features"],
+  PW: ["Material", "Features", "Eco Factors"],
+  PX: ["Material", "Features", "Local Factors"],
+  PY: ["Features", "Material", "Eco Factors"],
+};
+
+const FALLBACK_ATTRIBUTE_PRIORITY = [
+  "Features",
+  "Material",
+  "Capacity",
+  "Eco Factors",
+  "Sport",
+  "Local Factors",
+];
+
+const toAttributeQuestion = (attribute) => ({
+  id: `attribute-${attribute.name.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`,
+  label: attribute.name,
+  placeholder: `Any ${attribute.name.toLowerCase()}`,
+  type: "attribute",
+  attributeName: attribute.name,
+  options: attribute.values.map((value) => ({ label: value, value })),
+});
+
+const getDynamicAttributeQuestions = (productTypeId, attributes = []) => {
+  const available = new Map(
+    attributes
+      .filter(
+        (attribute) =>
+          attribute?.name &&
+          Array.isArray(attribute.values) &&
+          attribute.values.length > 0
+      )
+      .map((attribute) => [attribute.name, attribute])
+  );
+  const groupId = productTypeId?.split("-")[0];
+  const priorities = [
+    ...(ATTRIBUTE_PRIORITY_BY_GROUP[groupId] || []),
+    ...FALLBACK_ATTRIBUTE_PRIORITY,
+  ];
+
+  return [...new Set(priorities)]
+    .map((name) => available.get(name))
+    .filter(Boolean)
+    .slice(0, 2)
+    .map(toAttributeQuestion);
+};
+
 export const CATEGORY_FINDER_CONFIG = {
   "PE-02": {
     eyebrow: "Bottle Finder",
@@ -6,21 +123,7 @@ export const CATEGORY_FINDER_CONFIG = {
       "Choose what matters most and we’ll narrow the range. You can change or remove any filter afterwards.",
     submitLabel: "Show my matches",
     questions: [
-      {
-        id: "moq",
-        label: "Order quantity",
-        placeholder: "Any quantity",
-        type: "query",
-        queryParam: "moq",
-        options: [
-          { label: "1–24", value: "24" },
-          { label: "25–49", value: "49" },
-          { label: "50–99", value: "99" },
-          { label: "100–249", value: "249" },
-          { label: "250–499", value: "499" },
-          { label: "500+", value: "500" },
-        ],
-      },
+      ORDER_QUANTITY_QUESTION,
       {
         id: "capacity",
         label: "Capacity",
@@ -50,38 +153,42 @@ export const CATEGORY_FINDER_CONFIG = {
           { label: "Eco materials", value: "Bamboo,Wheat Straw,Cork,rPET" },
         ],
       },
-      {
-        id: "colour",
-        label: "Colour",
-        placeholder: "Any colour",
-        type: "query",
-        queryParam: "colors",
-        options: [
-          { label: "Black", value: "Black" },
-          { label: "White", value: "White" },
-          { label: "Blue", value: "Blue" },
-          { label: "Red", value: "Red" },
-          { label: "Green", value: "Green" },
-          { label: "Silver", value: "Silver" },
-          { label: "Natural", value: "Natural" },
-        ],
-      },
-      {
-        id: "budget",
-        label: "Unit budget (ex GST)",
-        placeholder: "Any budget",
-        type: "price",
-        options: [
-          { label: "Under $5", value: "0:5" },
-          { label: "$5–$10", value: "5:10" },
-          { label: "$10–$20", value: "10:20" },
-          { label: "$20–$35", value: "20:35" },
-          { label: "$35+", value: "35:" },
-        ],
-      },
+      COLOUR_QUESTION,
+      BUDGET_QUESTION,
     ],
   },
 };
 
-export const getCategoryFinderConfig = (productTypeId) =>
-  CATEGORY_FINDER_CONFIG[productTypeId] || null;
+export const getCategoryFinderConfig = (
+  productTypeId,
+  { attributes = [], categoryLabel = "" } = {}
+) => {
+  if (!productTypeId) return null;
+  if (CATEGORY_FINDER_CONFIG[productTypeId]) {
+    return CATEGORY_FINDER_CONFIG[productTypeId];
+  }
+
+  const attributeQuestions = getDynamicAttributeQuestions(
+    productTypeId,
+    attributes
+  );
+  if (attributeQuestions.length === 0) return null;
+
+  const label = categoryLabel.trim() || "products";
+  const labelLower = label.toLowerCase();
+
+  return {
+    eyebrow: `${label} Finder`,
+    title: `Find the right ${labelLower} in under 30 seconds`,
+    description:
+      "Choose what matters most and we’ll narrow the range. You can change or remove any filter afterwards.",
+    submitLabel: "Show my matches",
+    emptySubmitLabel: `View all ${labelLower}`,
+    questions: [
+      ORDER_QUANTITY_QUESTION,
+      ...attributeQuestions,
+      COLOUR_QUESTION,
+      BUDGET_QUESTION,
+    ],
+  };
+};


### PR DESCRIPTION
## What

- extend the guided Finder from Drink Bottles to every product subcategory with reliable structured attributes
- keep one reusable component and use category-family attribute priorities instead of separate category components
- retain the curated Bottle configuration as an override
- dynamically generate category-specific questions from the API’s available attributes
- hide the Finder when a category has no reliable attributes rather than showing empty controls
- replace bottle-specific empty-state wording with category-aware labels

## Category behaviour

Every eligible category receives order quantity, colour, unit budget, and up to two relevant structured attributes. Different attributes are ANDed; values grouped inside one answer are ORed.

Examples:
- Candles: Material + Eco Factors
- Blankets: Features (including Waterproof) + Material
- Drink Bottles: curated Capacity + Bottle type

## Checks

- `npm test -- --run src/__tests__/categoryFinderConfig.test.js` — 4 passed
- focused ESLint on all four changed files — passed
- `npm run build` — passed
- `git diff --check` — passed

## Dependency

The corrected quantity behaviour depends on backend PR #44 / commit `6d5f759` being deployed to the AWS API.