### PR TITLE
Align Finder/sidebar quantity wording, collapse Finder after submit

### DIFF
--- a/src/components/shared/MOQFilter.jsx
+++ b/src/components/shared/MOQFilter.jsx
@@ -2,18 +2,19 @@ import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useSearchParams } from "react-router-dom";
 import { setMoq } from "../../redux/slices/filterSlice";
+import { QUANTITY_OPTIONS, ANY_QUANTITY_LABEL } from "../../config/quantityOptions";
 
 const MOQFilter = ({ toggleSidebar }) => {
   const dispatch = useDispatch();
   const [searchParams, setSearchParams] = useSearchParams();
   const { moq } = useSelector((state) => state.filters);
 
+  // Same option list/wording as the guided Finder's order-quantity question
+  // (src/config/quantityOptions.js) — a value picked in one place must read
+  // identically in the other.
   const moqOptions = [
-    { label: "All Quantities", value: null },
-    { label: "50 or less", value: "50" },
-    { label: "100 or less", value: "100" },
-    { label: "250 or less", value: "250" },
-    { label: "500 or less", value: "500" },
+    { label: ANY_QUANTITY_LABEL, value: null },
+    ...QUANTITY_OPTIONS,
   ];
 
   const handleMoqChange = (value) => {

--- a/src/components/shared/UnifiedSidebar.jsx
+++ b/src/components/shared/UnifiedSidebar.jsx
@@ -58,6 +58,7 @@ import ClothingGenderToggle from "./ClothingGenderToggle";
 import CollapsibleSection from "./CollapsibleSection";
 import ColorFilter from "./ColorFilter";
 import MOQFilter from "./MOQFilter";
+import { QUANTITY_OPTIONS } from "../../config/quantityOptions";
 
 
 
@@ -116,9 +117,13 @@ const UnifiedSidebar = ({
 
     const moq = searchParams.get("moq");
     if (moq) {
+      // Same wording as the Finder's order-quantity question and the sidebar's own
+      // Minimum Quantity control (src/config/quantityOptions.js) — this applied-
+      // filter chip must read identically to whichever control set the value.
+      const matchedOption = QUANTITY_OPTIONS.find((option) => option.value === moq);
       filters.push({
         type: "moq",
-        label: `MOQ: ${moq} or less`,
+        label: `Order quantity: ${matchedOption?.label || moq}`,
         value: moq,
         params: ["moq"],
       });

--- a/src/components/shop/CategoryFinder.jsx
+++ b/src/components/shop/CategoryFinder.jsx
@@ -1,5 +1,5 @@
 import { getCategoryFinderConfig } from "@/config/categoryFinderConfig";
-import { Search, SlidersHorizontal, X } from "lucide-react";
+import { Pencil, Search, SlidersHorizontal, X } from "lucide-react";
 import PropTypes from "prop-types";
 import { useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "react-router-dom";
@@ -39,12 +39,26 @@ const CategoryFinder = ({ productTypeId }) => {
   const [selections, setSelections] = useState(() =>
     config ? readSelections(config, searchParams) : {}
   );
+  // Collapsed once the customer has already answered (either by submitting the
+  // Finder this visit, or by arriving with the same params already in the URL,
+  // e.g. a bookmarked/shared link) — the sidebar already reflects the same
+  // selections, so re-showing the full question grid would just be asking again.
+  const [collapsed, setCollapsed] = useState(() =>
+    config
+      ? Object.values(readSelections(config, searchParams)).some(Boolean)
+      : false
+  );
 
   useEffect(() => {
     if (config) {
       setSelections(readSelections(config, new URLSearchParams(searchParamsKey)));
     }
   }, [config, searchParamsKey]);
+
+  // A different category's Finder (new config identity) starts fresh/expanded.
+  useEffect(() => {
+    setCollapsed(false);
+  }, [config]);
 
   if (!config) return null;
 
@@ -54,6 +68,16 @@ const CategoryFinder = ({ productTypeId }) => {
     (left, right) =>
       (questionPriority[left.id] ?? 2) - (questionPriority[right.id] ?? 2)
   );
+
+  const summaryText = orderedQuestions
+    .map((question) => {
+      const value = selections[question.id];
+      if (!value) return null;
+      const matchedOption = question.options.find((option) => option.value === value);
+      return `${question.label}: ${matchedOption?.label || value}`;
+    })
+    .filter(Boolean)
+    .join(" · ");
 
   const applyFinder = () => {
     const next = new URLSearchParams(searchParams);
@@ -90,6 +114,7 @@ const CategoryFinder = ({ productTypeId }) => {
     next.set("page", "1");
     next.delete("scrollTo");
     setSearchParams(next);
+    setCollapsed(true);
   };
 
   const clearFinder = () => {
@@ -122,6 +147,7 @@ const CategoryFinder = ({ productTypeId }) => {
     next.delete("scrollTo");
     setSelections(readSelections(config, new URLSearchParams()));
     setSearchParams(next);
+    setCollapsed(false);
   };
 
   return (
@@ -140,62 +166,86 @@ const CategoryFinder = ({ productTypeId }) => {
           </p>
         </div>
 
-        <div>
-          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
-            {orderedQuestions.map((question) => (
-              <label key={question.id} className="block">
-                <span className="mb-1.5 block text-xs font-semibold text-gray-700">
-                  {question.label}
-                </span>
-                <select
-                  value={selections[question.id] || ""}
-                  onChange={(event) =>
-                    setSelections((current) => ({
-                      ...current,
-                      [question.id]: event.target.value,
-                    }))
-                  }
-                  className="h-11 w-full rounded-lg border border-gray-300 bg-white px-3 text-sm text-gray-900 outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/15"
-                >
-                  <option value="">{question.placeholder}</option>
-                  {question.options.map((option) => (
-                    <option key={option.value} value={option.value}>
-                      {option.label}
-                    </option>
-                  ))}
-                </select>
-              </label>
-            ))}
-          </div>
-
-          <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-            <p className="text-xs text-gray-500">
-              {selectedCount
-                ? `${selectedCount} preference${selectedCount === 1 ? "" : "s"} selected`
-                : "Choose one or more preferences, or continue with all bottles."}
+        {collapsed ? (
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-sm text-gray-700">
+              {summaryText ? (
+                <>
+                  <span className="font-semibold text-gray-900">Your picks: </span>
+                  {summaryText}
+                </>
+              ) : (
+                "Showing all bottles."
+              )}
+              {" "}Adjust anything below, or edit your answers here.
             </p>
-            <div className="flex flex-col gap-2 sm:flex-row">
-              {selectedCount > 0 && (
+            <button
+              type="button"
+              onClick={() => setCollapsed(false)}
+              className="inline-flex h-10 shrink-0 items-center justify-center gap-2 rounded-lg border border-gray-300 bg-white px-4 text-sm font-semibold text-gray-700 transition hover:bg-gray-50"
+            >
+              <Pencil className="h-4 w-4" />
+              Edit my answers
+            </button>
+          </div>
+        ) : (
+          <div>
+            <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
+              {orderedQuestions.map((question) => (
+                <label key={question.id} className="block">
+                  <span className="mb-1.5 block text-xs font-semibold text-gray-700">
+                    {question.label}
+                  </span>
+                  <select
+                    value={selections[question.id] || ""}
+                    onChange={(event) =>
+                      setSelections((current) => ({
+                        ...current,
+                        [question.id]: event.target.value,
+                      }))
+                    }
+                    className="h-11 w-full rounded-lg border border-gray-300 bg-white px-3 text-sm text-gray-900 outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/15"
+                  >
+                    <option value="">{question.placeholder}</option>
+                    {question.options.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              ))}
+            </div>
+
+            <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-xs text-gray-500">
+                {selectedCount
+                  ? `${selectedCount} preference${selectedCount === 1 ? "" : "s"} selected`
+                  : "Choose one or more preferences, or continue with all bottles."}
+              </p>
+              <div className="flex flex-col gap-2 sm:flex-row">
+                {selectedCount > 0 && (
+                  <button
+                    type="button"
+                    onClick={clearFinder}
+                    className="inline-flex h-11 items-center justify-center gap-2 rounded-lg border border-gray-300 bg-white px-4 text-sm font-semibold text-gray-700 transition hover:bg-gray-50"
+                  >
+                    <X className="h-4 w-4" />
+                    Clear
+                  </button>
+                )}
                 <button
                   type="button"
-                  onClick={clearFinder}
-                  className="inline-flex h-11 items-center justify-center gap-2 rounded-lg border border-gray-300 bg-white px-4 text-sm font-semibold text-gray-700 transition hover:bg-gray-50"
+                  onClick={applyFinder}
+                  className="inline-flex h-11 items-center justify-center gap-2 rounded-lg bg-primary px-5 text-sm font-semibold text-white shadow-sm transition hover:bg-primary/90"
                 >
-                  <X className="h-4 w-4" />
-                  Clear
+                  <Search className="h-4 w-4" />
+                  {selectedCount ? config.submitLabel : "View all bottles"}
                 </button>
-              )}
-              <button
-                type="button"
-                onClick={applyFinder}
-                className="inline-flex h-11 items-center justify-center gap-2 rounded-lg bg-primary px-5 text-sm font-semibold text-white shadow-sm transition hover:bg-primary/90"
-              >
-                <Search className="h-4 w-4" />
-                {selectedCount ? config.submitLabel : "View all bottles"}
-              </button>
+              </div>
             </div>
           </div>
-        </div>
+        )}
       </div>
     </section>
   );

--- a/src/config/categoryFinderConfig.js
+++ b/src/config/categoryFinderConfig.js
@@ -1,3 +1,5 @@
+import { QUANTITY_OPTIONS, ANY_QUANTITY_LABEL } from "./quantityOptions";
+
 export const CATEGORY_FINDER_CONFIG = {
   "PE-02": {
     eyebrow: "Bottle Finder",
@@ -9,17 +11,10 @@ export const CATEGORY_FINDER_CONFIG = {
       {
         id: "moq",
         label: "Order quantity",
-        placeholder: "Any quantity",
+        placeholder: ANY_QUANTITY_LABEL,
         type: "query",
         queryParam: "moq",
-        options: [
-          { label: "1–24", value: "24" },
-          { label: "25–49", value: "49" },
-          { label: "50–99", value: "99" },
-          { label: "100–249", value: "249" },
-          { label: "250–499", value: "499" },
-          { label: "500+", value: "500" },
-        ],
+        options: QUANTITY_OPTIONS,
       },
       {
         id: "capacity",

--- a/src/config/quantityOptions.js
+++ b/src/config/quantityOptions.js
@@ -1,0 +1,19 @@
+// Single source of truth for order-quantity bucket wording, shared by the guided
+// Finder (CategoryFinder.jsx) and the category sidebar (MOQFilter.jsx). Both send
+// the same `moq` query param with the same values, so the labels a customer sees
+// must match exactly regardless of which control they used — picking "50-99" in
+// one place and seeing "100 or less" for the same underlying value in the other
+// reads as two disagreeing filters, not one filter shown twice.
+export const QUANTITY_OPTIONS = [
+  { label: "1–24", value: "24" },
+  { label: "25–49", value: "49" },
+  { label: "50–99", value: "99" },
+  { label: "100–249", value: "249" },
+  { label: "250–499", value: "499" },
+  { label: "500+", value: "500" },
+];
+
+// Shared wording for the "nothing selected" state — the Finder shows this as a
+// <select> placeholder, the sidebar shows it as an explicit radio option, but the
+// text should read identically either way.
+export const ANY_QUANTITY_LABEL = "Any quantity";


### PR DESCRIPTION
## Summary

Depends on the backend quantity-aware pricing fix (super-merch/supermerch-backend#45) for the actual pricing correctness — this PR is the frontend UX follow-up requested alongside it:

1. **Wording alignment**: the Finder's "Order quantity" question, the sidebar's "Minimum Quantity" filter, and the sidebar's applied-filter chip each had their own, independently-worded option list for the same `moq` value (e.g. "50–99" in the Finder vs "100 or less" in the sidebar vs "MOQ: 99 or less" in the chip). The same selection could read as three different things depending on which control produced it.
2. **Collapse after submit**: after clicking "Show my matches", the Finder stayed fully expanded even though the sidebar already reflected the exact same selections — reading as "why is it asking me again" rather than one filter shown two ways.

## Changes

- **`src/config/quantityOptions.js`** (new): single canonical `{label, value}` list + shared "no selection" label, imported by `categoryFinderConfig.js` (Finder), `MOQFilter.jsx` (sidebar), and `UnifiedSidebar.jsx` (applied-filter chip) so all three read identically and can't drift apart again.
- **`CategoryFinder.jsx`**: collapses to a compact summary bar ("Your picks: Order quantity: 50–99 · Unit budget: Under $5 · Edit my answers") after submit. An "Edit my answers" link re-expands the full form without losing the current results. Starts expanded on a fresh category, and re-expands after "Clear".

## Testing

- All 51 existing tests pass (`vitest run`), production build succeeds.
- Verified live in a browser against the real backend (with the paired backend PR applied): confirmed identical wording across the Finder, sidebar radio list, and applied-filter chip; confirmed the collapse → sidebar-sync → "Edit my answers" → re-expand round trip; confirmed filtering correctly narrows results (738 → 1 product) with the quantity-aware price shown on the remaining product matching the budget filter.

No merge/deploy — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)