### PR TITLE
Fix FAQ/Privacy/Terms/Refund/Artwork pages calling relative API paths

### DIFF
--- a/src/components/Common/LogoutModal.jsx
+++ b/src/components/Common/LogoutModal.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { LuCircleAlert, LuX } from "react-icons/lu";
+import { LuAlertCircle, LuX } from "react-icons/lu";
 import { motion } from "framer-motion";
 
 const LogoutModal = ({ showLogoutPopup, setShowLogoutPopup, handleLogout }) => {
@@ -27,7 +27,7 @@ const LogoutModal = ({ showLogoutPopup, setShowLogoutPopup, handleLogout }) => {
         <div className="px-6 pt-6 pb-4">
           <div className="flex items-center gap-3 mb-2">
             <div className="flex-shrink-0 w-10 h-10 rounded-full bg-red-100 flex items-center justify-center">
-              <LuCircleAlert className="w-5 h-5 text-red-600" />
+              <LuAlertCircle className="w-5 h-5 text-red-600" />
             </div>
             <h3
               id="logout-modal-title"

--- a/src/pages/ArtWorkPolicy.jsx
+++ b/src/pages/ArtWorkPolicy.jsx
@@ -6,7 +6,7 @@ const ArtWorkPolicy = () => {
   const [error, setError] = useState(null);
 
   useEffect(() => {
-    fetch("/api/policies/by-type/artwork")
+    fetch(`${import.meta.env.VITE_BACKEND_URL}/api/policies/by-type/artwork`)
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}: ${res.statusText}`);
         return res.json();

--- a/src/pages/FAQs.jsx
+++ b/src/pages/FAQs.jsx
@@ -9,7 +9,7 @@ export default function FAQs() {
   const [error, setError] = useState(null);
 
   useEffect(() => {
-    fetch("/api/faqs/active")
+    fetch(`${import.meta.env.VITE_BACKEND_URL}/api/faqs/active`)
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}: ${res.statusText}`);
         return res.json();

--- a/src/pages/PrivacyPolicy.jsx
+++ b/src/pages/PrivacyPolicy.jsx
@@ -6,7 +6,7 @@ export default function PrivacyPolicy() {
   const [error, setError] = useState(null);
 
   useEffect(() => {
-    fetch("/api/policies/by-type/privacy")
+    fetch(`${import.meta.env.VITE_BACKEND_URL}/api/policies/by-type/privacy`)
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}: ${res.statusText}`);
         return res.json();

--- a/src/pages/RefundPolicy.jsx
+++ b/src/pages/RefundPolicy.jsx
@@ -6,7 +6,7 @@ const RefundPolicy = () => {
   const [error, setError] = useState(null);
 
   useEffect(() => {
-    fetch("/api/policies/by-type/refund")
+    fetch(`${import.meta.env.VITE_BACKEND_URL}/api/policies/by-type/refund`)
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}: ${res.statusText}`);
         return res.json();

--- a/src/pages/Terms.jsx
+++ b/src/pages/Terms.jsx
@@ -6,7 +6,7 @@ export default function Terms() {
   const [error, setError] = useState(null);
 
   useEffect(() => {
-    fetch("/api/policies/by-type/terms")
+    fetch(`${import.meta.env.VITE_BACKEND_URL}/api/policies/by-type/terms`)
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}: ${res.statusText}`);
         return res.json();


### PR DESCRIPTION
## Summary
All five pages (FAQs, Privacy, Terms, Refund, Artwork) called `fetch("/api/...")` with no backend domain. Since `vercel.json` rewrites every unmatched path to `index.html`, the request hit the SPA's own HTML instead of the real backend, failing to parse as JSON ("Unexpected token '<'").

Fixed by prefixing each with `VITE_BACKEND_URL`, matching the pattern already used throughout this codebase (AuthContext, ProductsContext, etc).

Companion backend fix (adding the previously-missing routes these calls hit): `super-merch/supermerch-backend#fix/faq-policy-routes`.

Also fixes an unrelated build-breaking bug found while verifying this: `LogoutModal.jsx` imported `LuCircleAlert`, which isn't exported by the installed `react-icons` version (renamed upstream to `LuAlertCircle`) — this was blocking `npm run build` entirely.

## Test plan
- [x] `npm run build` succeeds
- [x] Verified locally against a seeded test database (real backend + real Mongo data) — all 5 pages render correct content, no errors
- [x] Confirmed via live network trace that the fetch now reaches the correct backend domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)