### PR TITLE
Fix Vercel build failure: revert LuAlertCircle regression from #162

### DIFF
--- a/src/components/Common/LogoutModal.jsx
+++ b/src/components/Common/LogoutModal.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { LuAlertCircle, LuX } from "react-icons/lu";
+import { LuCircleAlert, LuX } from "react-icons/lu";
 import { motion } from "framer-motion";
 
 const LogoutModal = ({ showLogoutPopup, setShowLogoutPopup, handleLogout }) => {
@@ -27,7 +27,7 @@ const LogoutModal = ({ showLogoutPopup, setShowLogoutPopup, handleLogout }) => {
         <div className="px-6 pt-6 pb-4">
           <div className="flex items-center gap-3 mb-2">
             <div className="flex-shrink-0 w-10 h-10 rounded-full bg-red-100 flex items-center justify-center">
-              <LuAlertCircle className="w-5 h-5 text-red-600" />
+              <LuCircleAlert className="w-5 h-5 text-red-600" />
             </div>
             <h3
               id="logout-modal-title"


### PR DESCRIPTION
## Summary
My previous PR (#162) included an incorrect "fix" to `LogoutModal.jsx` — renaming `LuCircleAlert` to `LuAlertCircle`. That was based on a stale local `react-icons@5.3.0` install. This repo has no lockfile, so real installs resolve `react-icons@5.7.0`, which only exports `LuCircleAlert`. The mismatch broke the actual Vercel production build for #162's merge commit (confirmed failed via the GitHub Deployments API).

This was never broken in production before #162 — this PR just reverts that one incorrect change.

**This is currently blocking the real fix in #162 from being live** — recommend merging ASAP.

## Test plan
- [x] Fresh `npm install` (matching Vercel's actual build, no lockfile in this repo) + `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)