### PR TITLE
Temporarily hide homepage Hot Deals box content

### DIFF
--- a/src/components/Home/HotDeals.jsx
+++ b/src/components/Home/HotDeals.jsx
@@ -1,38 +1,21 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { FaFire } from "react-icons/fa";
 import { Link } from "react-router-dom";
-import axios from "axios";
 import noimage from "/noimage.png";
 import Tooltip from "../Common/Tooltip";
 
 const HotDeals = () => {
   const [deals, setDeals] = useState([]);
   const [loading, setLoading] = useState(true);
-  const hasRequestedRef = useRef(false);
 
   const backendUrl = import.meta.env.VITE_BACKEND_URL;
 
   useEffect(() => {
-    if (hasRequestedRef.current) return;
-
-    const fetchDeals = async () => {
-      try {
-        hasRequestedRef.current = true;
-        setLoading(true);
-
-        const response = await axios.get(`${backendUrl}/api/frontend/deals?limit=4&featured=true`);
-
-        if (response.data?.success) {
-          setDeals(response.data.data);
-        }
-      } catch (error) {
-        console.error('Error fetching deals:', error);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchDeals();
+    // Temporarily disabled: the only featured deal currently returned by the
+    // backend has incorrect pricing/imagery. Leaving `deals` empty renders
+    // the existing "no deals" fallback below. Re-enable once the featured
+    // deal data is corrected.
+    setLoading(false);
   }, [backendUrl]);
 
   return (


### PR DESCRIPTION
## Summary
The homepage's "Hot Deals" sidebar box fetches whatever deal is marked `featured: true` from the backend. Right now that's the "Exclusive Tshirts" deal with incorrect pricing ($1,111 for 3 t-shirts) and a mismatched (appliance/washing-machine) banner image.

Per request, this stops the fetch and lets the box fall through to its existing "no deals" fallback UI instead of showing broken data. Frontend-only, no backend/database touched — easily reversible by restoring the `fetchDeals()` call once the featured deal data is corrected in the admin panel.

## Test plan
- [x] `npm run build` succeeds
- [x] Verified locally in the browser — box now shows the clean "Explore promotional merchandise / Shop all products" fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)