### PR TITLE
Show catalogue API failures instead of empty results

### DIFF
--- a/src/__tests__/productsErrorState.render.test.jsx
+++ b/src/__tests__/productsErrorState.render.test.jsx
@@ -1,0 +1,149 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import Cards from "../components/shop/Cards";
+import { AppContext } from "../context/AppContext";
+import { ProductsContext } from "../context/ProductsContext";
+
+vi.mock("react-redux", () => ({
+  useDispatch: () => vi.fn(),
+  useSelector: () => ({ minPrice: 0, maxPrice: 1000000 }),
+}));
+
+vi.mock("../components/Common/ProductCard", () => ({
+  default: ({ product }) => <div data-testid="product-card">{product?.overview?.name}</div>,
+}));
+vi.mock("../components/Common/SkeletonLoadingCards", () => ({
+  default: () => <div data-testid="skeleton" />,
+}));
+vi.mock("../components/Common/EmptyState", () => ({
+  default: ({ title }) => <div>{title}</div>,
+}));
+vi.mock("../components/shared/UnifiedSidebar", () => ({
+  default: () => <aside data-testid="sidebar" />,
+}));
+vi.mock("../components/shop/CategoryFinder", () => ({
+  default: () => null,
+}));
+vi.mock("../config/sidebarConfig", () => ({
+  getPageTypeFromRoute: () => "shop",
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const product = {
+  meta: { id: 1 },
+  overview: { name: "Recovered Bottle" },
+};
+
+const baseContext = {
+  paginationData: {
+    productTypeId: "PE-02",
+    page: 1,
+    limit: 20,
+    sortOption: "",
+    filter: true,
+    category: null,
+    searchTerm: "",
+    pricerange: undefined,
+    colors: [],
+    attributes: null,
+    sendAttributes: true,
+    expressWindow: null,
+    moq: null,
+  },
+  setPaginationData: vi.fn(),
+  getProducts: { data: [], item_count: 0 },
+  productsLoading: false,
+  productsFetching: false,
+  productsIsError: false,
+  productsError: null,
+  refetchProducts: vi.fn(),
+};
+
+function renderCards(overrides = {}) {
+  const value = { ...baseContext, ...overrides };
+  return {
+    ...render(
+      <MemoryRouter initialEntries={["/shop?category=PE-02"]}>
+        <AppContext.Provider value={{ backendUrl: "https://api.example.test" }}>
+          <ProductsContext.Provider value={value}>
+            <Cards />
+          </ProductsContext.Provider>
+        </AppContext.Provider>
+      </MemoryRouter>
+    ),
+    value,
+  };
+}
+
+describe("Cards catalogue request states", () => {
+  it("renders a retryable service error for an API failure", () => {
+    renderCards({
+      productsIsError: true,
+      productsError: new Error("Product request failed with HTTP 500"),
+    });
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Products are temporarily unavailable"
+    );
+    expect(screen.getByText(/filters have been preserved/i)).toBeInTheDocument();
+    expect(screen.queryByText("No Products Found")).not.toBeInTheDocument();
+  });
+
+  it("invokes the existing React Query refetch action", () => {
+    const refetchProducts = vi.fn();
+    renderCards({ productsIsError: true, refetchProducts });
+
+    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+    expect(refetchProducts).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the genuine empty-catalogue state for a successful empty response", () => {
+    renderCards({
+      productsIsError: false,
+      getProducts: { data: [], item_count: 0 },
+    });
+
+    expect(screen.getByText("No Products Found")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Products are temporarily unavailable")
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides stale products during failure and restores successful retry data", () => {
+    const initial = {
+      productsIsError: true,
+      getProducts: { data: [product], item_count: 1 },
+    };
+    const { rerender } = renderCards(initial);
+
+    expect(screen.queryByTestId("product-card")).not.toBeInTheDocument();
+
+    rerender(
+      <MemoryRouter initialEntries={["/shop?category=PE-02"]}>
+        <AppContext.Provider value={{ backendUrl: "https://api.example.test" }}>
+          <ProductsContext.Provider
+            value={{
+              ...baseContext,
+              productsIsError: false,
+              getProducts: { data: [product], item_count: 1 },
+            }}
+          >
+            <Cards />
+          </ProductsContext.Provider>
+        </AppContext.Provider>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId("product-card")).toHaveTextContent(
+      "Recovered Bottle"
+    );
+  });
+});

--- a/src/__tests__/productsErrorState.test.js
+++ b/src/__tests__/productsErrorState.test.js
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+const contextSource = readFileSync(
+  new URL("../context/ProductsContext.jsx", import.meta.url),
+  "utf8"
+);
+const cardsSource = readFileSync(
+  new URL("../components/shop/Cards.jsx", import.meta.url),
+  "utf8"
+);
+
+describe("catalogue request error handling", () => {
+  it("rejects non-successful and malformed product responses", () => {
+    expect(contextSource).toContain("if (!res.ok)");
+    expect(contextSource).toContain("Product request failed with HTTP");
+    expect(contextSource).toContain("!Array.isArray(data.data)");
+  });
+
+  it("exposes React Query error state through ProductsContext", () => {
+    expect(contextSource).toContain("isError: productsIsError");
+    expect(contextSource).toContain("error: productsError");
+    expect(contextSource).toMatch(/productsIsError,\s*productsError,\s*refetchProducts/);
+  });
+
+  it("renders a retryable service error instead of a genuine empty result", () => {
+    const errorBranch = cardsSource.indexOf("productsIsError ? (");
+    const emptyState = cardsSource.indexOf('title="No Products Found"');
+    expect(errorBranch).toBeGreaterThan(-1);
+    expect(emptyState).toBeGreaterThan(errorBranch);
+    expect(cardsSource).toContain("Products are temporarily unavailable");
+    expect(cardsSource).toContain("onClick={() => refetchProducts()}");
+  });
+});

--- a/src/components/shop/Cards.jsx
+++ b/src/components/shop/Cards.jsx
@@ -57,6 +57,9 @@ const Cards = ({ category = "" }) => {
     getProducts,
     productsLoading,
     productsFetching,
+    productsIsError,
+    productsError,
+    refetchProducts,
   } = useContext(ProductsContext);
   const isProductsLoading = productsLoading || productsFetching;
   const { backendUrl } = useContext(AppContext);
@@ -793,6 +796,28 @@ const Cards = ({ category = "" }) => {
               Array.from({ length: 20 }, (_, index) => (
                 <SkeletonLoadingCards key={index} />
               ))
+            ) : productsIsError ? (
+              <div
+                className="col-span-full mx-auto my-10 max-w-xl rounded-lg border border-red-200 bg-red-50 p-6 text-center"
+                role="alert"
+              >
+                <h2 className="mb-2 text-xl font-semibold text-gray-900">
+                  Products are temporarily unavailable
+                </h2>
+                <p className="mb-4 text-gray-700">
+                  We couldn&apos;t load this catalogue. Your filters have been preserved.
+                </p>
+                <button
+                  type="button"
+                  onClick={() => refetchProducts()}
+                  className="rounded-lg bg-primary px-5 py-2.5 font-medium text-white hover:bg-primary/90"
+                >
+                  Try again
+                </button>
+                {import.meta.env.DEV && productsError?.message ? (
+                  <p className="mt-3 text-xs text-gray-500">{productsError.message}</p>
+                ) : null}
+              </div>
             ) : (accumulatedProducts?.length > 0 || getProducts?.data?.length > 0) ? (
               <>
                 <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-2.5 sm:gap-3 md:gap-4 lg:gap-5 md:mt-5 mt-3 w-full">

--- a/src/context/ProductsContext.jsx
+++ b/src/context/ProductsContext.jsx
@@ -174,7 +174,14 @@ const ProductsContextProvider = ({ children }) => {
         }
 
         const res = await fetch(url);
+        if (!res.ok) {
+            throw new Error(`Product request failed with HTTP ${res.status}`);
+        }
         const data = await res.json();
+
+        if (!data || !Array.isArray(data.data)) {
+            throw new Error("Product request returned an invalid response");
+        }
 
         setTotalCount(
             data.total_count ||
@@ -187,7 +194,14 @@ const ProductsContextProvider = ({ children }) => {
         return data;
     };
 
-    const { data: getProducts, isLoading: productsLoading, isFetching: productsFetching, refetch: refetchProducts } = useQuery({
+    const {
+        data: getProducts,
+        isLoading: productsLoading,
+        isFetching: productsFetching,
+        isError: productsIsError,
+        error: productsError,
+        refetch: refetchProducts,
+    } = useQuery({
         queryKey: [
             paginationData.productTypeId,
             paginationData.page,
@@ -1344,6 +1358,8 @@ const ProductsContextProvider = ({ children }) => {
             getProducts,
             productsLoading,
             productsFetching,
+            productsIsError,
+            productsError,
             refetchProducts,
 
 
@@ -1409,6 +1425,8 @@ const ProductsContextProvider = ({ children }) => {
             getProducts,
             productsLoading,
             productsFetching,
+            productsIsError,
+            productsError,
             refetchProducts,
 
             products,


### PR DESCRIPTION
## Summary

Production QA exposed that catalogue API transport failures are currently rendered as a legitimate **No Products Found** result. This can mislead customers and makes operational failures indistinguishable from a genuinely empty filter.

This PR:

- rejects non-2xx and malformed product responses in `ProductsContext`;
- exposes React Query's error state to catalogue consumers;
- renders a clear, retryable service-error panel in `Cards`;
- preserves the customer's current URL filters;
- retains the existing empty state for successful responses containing zero products.

## Evidence

During the 297-leaf production sweep, an identical Backpacks URL first returned 191 products and later returned zero while the browser console simultaneously logged multiple `Failed to fetch`/network errors. The UI showed the normal empty-catalogue message.

## Testing

Adds `productsErrorState.test.js` covering response validation, context exposure, retry wiring, and branch ordering so the error state cannot silently fall through to the empty state.

Not merged or deployed.