### PR TITLE
Fix security vulnerabilities: swiper upgrade + remove stray .htaccess

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "react-toastify": "^11.0.3",
     "redux-persist": "^6.0.0",
     "slick-carousel": "^1.8.1",
-    "swiper": "^11.2.2",
+    "swiper": "^14.0.7",
     "tailwind-merge": "^3.0.2",
     "tailwindcss-animate": "^1.0.7"
   },

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,6 +1,0 @@
-Options -MultiViews
-RewriteEngine On
-
-RewriteCond %{REQUEST_FILENAME} !-f
-RewriteCond %{REQUEST_FILENAME} !-d
-RewriteRule ^ index.html [QSA,L]


### PR DESCRIPTION
## Summary
Fixes the frontend issues found in this session's live scan (validated against actual usage before applying).

- **Upgraded `swiper` 11.2.2 → 14.0.7** — fixes critical prototype-pollution advisory. Verified live in browser: the homepage's "TRENDING NOW" carousel renders correctly with real product data, slide counter working ("1 / 14"), zero console errors. The app's usage pattern (`swiper/react` + `swiper/modules`) is unaffected by v14's breaking changes.
- **Removed `public/.htaccess`** — a leftover Apache rewrite rule from a prior hosting setup. Vercel doesn't process `.htaccess` at all; confirmed `vercel.json` already has its own equivalent catch-all rewrite. This file did nothing except sit there as an unnecessarily exposed static file (a security scanner flagged it as accessible, which is how this was found).

## Deliberately not changed, with reasoning
- **`react-router`/`react-router-dom`'s CSRF advisory** (`GHSA-qwww-vcr4-c8h2`) is scoped to React Router's "RSC Mode." Confirmed zero usage of that mode anywhere in this codebase (no `createBrowserRouter`, no loaders/actions — just plain `<Routes>`/`<Route>`). Not forcing the major v7→v8 bump for a non-applicable attack surface.
- **`vitest`'s critical advisory** is dev-only build tooling with zero production exposure. Attempted the fix (bump to v4.1.10) but it broke one test file's file-URL handling — reverted. Not worth chasing for a risk that only matters if someone's running the local dev server.

## Verification
- Full test suite: 1765/1765 pass, no regressions
- Production build: succeeds, bundle sizes unchanged
- Live browser check of the Swiper carousel: working correctly, no console errors

## Scope
Frontend only. Not merged, not deployed — same as every other change this session.