### PR TITLE
Wire up guest-access-token for checkout order lookup

### DIFF
--- a/src/components/checkout/Checkout.jsx
+++ b/src/components/checkout/Checkout.jsx
@@ -220,6 +220,21 @@ const Checkout = () => {
       const orderId =
         createdOrder?.orderId || createdOrder?.orderNumber || createdOrder?._id;
 
+      // A guest (no account) has no other way to prove this order is theirs.
+      // The backend hands this token out once, here, and requires it (or
+      // ownership/staff auth) for any later lookup of the order by id.
+      if (createdOrder?._id && createdOrder?.guestAccessToken) {
+        try {
+          localStorage.setItem(
+            `guestOrderToken_${createdOrder._id}`,
+            createdOrder.guestAccessToken,
+          );
+        } catch {
+          // localStorage unavailable (private browsing, etc.) — the
+          // customer can still track the order while logged in.
+        }
+      }
+
       if (orderId) {
         navigate(`/track-order?order=${encodeURIComponent(orderId)}&source=checkout`, {
           replace: true,

--- a/src/components/checkout/Checkout.jsx
+++ b/src/components/checkout/Checkout.jsx
@@ -222,13 +222,24 @@ const Checkout = () => {
 
       // A guest (no account) has no other way to prove this order is theirs.
       // The backend hands this token out once, here, and requires it (or
-      // ownership/staff auth) for any later lookup of the order by id.
-      if (createdOrder?._id && createdOrder?.guestAccessToken) {
+      // ownership/staff auth) for any later lookup of the order. Stored
+      // under both identifiers since different pages land with different
+      // ones: /track-order uses the human order number, the account area
+      // uses the Mongo id.
+      if (createdOrder?.guestAccessToken) {
         try {
-          localStorage.setItem(
-            `guestOrderToken_${createdOrder._id}`,
-            createdOrder.guestAccessToken,
-          );
+          if (createdOrder._id) {
+            localStorage.setItem(
+              `guestOrderToken_${createdOrder._id}`,
+              createdOrder.guestAccessToken,
+            );
+          }
+          if (createdOrder.orderId) {
+            localStorage.setItem(
+              `guestOrderToken_${createdOrder.orderId}`,
+              createdOrder.guestAccessToken,
+            );
+          }
         } catch {
           // localStorage unavailable (private browsing, etc.) — the
           // customer can still track the order while logged in.

--- a/src/pages/TrackOrder.jsx
+++ b/src/pages/TrackOrder.jsx
@@ -129,8 +129,25 @@ export default function TrackOrder() {
     setLoading(true);
     try {
       const params = email.trim() ? `?email=${encodeURIComponent(email.trim())}` : "";
+
+      // An order number alone is not proof of ownership (numbers are
+      // sequential). Send whichever proof is available: the guest token
+      // handed out once at checkout (stored locally, same browser), or a
+      // logged-in customer's own auth token. Neither is required if the
+      // caller supplies the order's email instead.
+      const headers = {};
+      const loggedInToken = localStorage.getItem("token");
+      if (loggedInToken) headers.token = loggedInToken;
+      try {
+        const guestToken = localStorage.getItem(`guestOrderToken_${orderNum.trim()}`);
+        if (guestToken) headers["x-guest-order-token"] = guestToken;
+      } catch {
+        // localStorage unavailable — fall through with whatever else we have
+      }
+
       const { data } = await axios.get(
-        `${backendUrl}/api/user-orders/track/${orderNum.trim()}${params}`
+        `${backendUrl}/api/user-orders/track/${orderNum.trim()}${params}`,
+        { headers }
       );
       if (data.success) {
         setOrderData(data.data);
@@ -138,7 +155,12 @@ export default function TrackOrder() {
         setError(data.message || "Order not found");
       }
     } catch (err) {
-      const msg = err.response?.data?.message || "Order not found. Please check your details.";
+      const noProofAvailable = !email.trim() && !localStorage.getItem("token");
+      const msg =
+        err.response?.data?.message ||
+        (noProofAvailable
+          ? "Order not found. If you're tracking from a different device or browser, enter the email used for this order."
+          : "Order not found. Please check your details.");
       setError(msg);
     } finally {
       setLoading(false);

--- a/src/userAdmin/UserProducts.jsx
+++ b/src/userAdmin/UserProducts.jsx
@@ -165,22 +165,21 @@ const UserProducts = () => {
 
       try {
         const token = localStorage.getItem("token");
-        const config = token ? { headers: { token } } : undefined;
+        const headers = token ? { token } : {};
         // A guest (no account) has no other way to prove this order is
         // theirs — the token was handed to them once, right after checkout.
-        let guestAccessToken = null;
+        // Sent as a dedicated header, not a query string, which would leak
+        // into browser history/logs/referrers.
         try {
-          guestAccessToken = localStorage.getItem(`guestOrderToken_${orderId}`);
+          const guestAccessToken = localStorage.getItem(`guestOrderToken_${orderId}`);
+          if (guestAccessToken) headers["x-guest-order-token"] = guestAccessToken;
         } catch {
           // localStorage unavailable — fall through with no token; a
-          // logged-in customer's own auth still works via `config`.
+          // logged-in customer's own auth still works via the `token` header.
         }
-        const query = guestAccessToken
-          ? `?accessToken=${encodeURIComponent(guestAccessToken)}`
-          : "";
         const { data } = await axios.get(
-          `${backendUrl}/api/checkout/products/${orderId}${query}`,
-          config,
+          `${backendUrl}/api/checkout/products/${orderId}`,
+          { headers },
         );
         const fetchedOrder = data?.data?.[0] || null;
         if (!cancelled) setSelectedOrder(fetchedOrder);

--- a/src/userAdmin/UserProducts.jsx
+++ b/src/userAdmin/UserProducts.jsx
@@ -166,8 +166,20 @@ const UserProducts = () => {
       try {
         const token = localStorage.getItem("token");
         const config = token ? { headers: { token } } : undefined;
+        // A guest (no account) has no other way to prove this order is
+        // theirs — the token was handed to them once, right after checkout.
+        let guestAccessToken = null;
+        try {
+          guestAccessToken = localStorage.getItem(`guestOrderToken_${orderId}`);
+        } catch {
+          // localStorage unavailable — fall through with no token; a
+          // logged-in customer's own auth still works via `config`.
+        }
+        const query = guestAccessToken
+          ? `?accessToken=${encodeURIComponent(guestAccessToken)}`
+          : "";
         const { data } = await axios.get(
-          `${backendUrl}/api/checkout/products/${orderId}`,
+          `${backendUrl}/api/checkout/products/${orderId}${query}`,
           config,
         );
         const fetchedOrder = data?.data?.[0] || null;


### PR DESCRIPTION
## Summary
Companion to [supermerch-backend#72](https://github.com/super-merch/supermerch-backend/pull/72). Two commits:

1. Wires the checkout-issued guest access token into `UserProducts.jsx`'s order-lookup fallback.
2. **Fixes the actual guest confirmation flow.** ChatGPT's review caught that commit 1 wired the token into the wrong page — `Checkout.jsx` navigates guests to `/track-order` after checkout, which calls `GET /api/user-orders/track/:orderNumber`, a completely different (and, until the backend's 2nd commit, still-unauthenticated and enumerable) endpoint.

## Changes
- `Checkout.jsx`: stores `guestAccessToken` (returned in the create-checkout response) under **both** the order's Mongo id and its human order number (`SM000...`), since different pages land with different identifiers.
- `TrackOrder.jsx` (the real post-checkout guest landing page): sends the stored guest token — or the logged-in customer's own auth token, if present — via a dedicated header (`x-guest-order-token`), never a query string (which leaks into browser history/logs/referrers). Falls back to the existing order-number + matching email flow when no other proof is available, matching the backend's own fallback.
- `UserProducts.jsx`: switched from `?accessToken=` to the same header, for consistency with the backend's now-header-only contract.

Logged-in customers are unaffected — their own JWT already proves ownership without any of this.

## Test plan
- [x] `npx eslint` on all three changed files — only pre-existing, unrelated warnings/errors; nothing from this diff.
- [ ] Manual click-through: guest checkout → land on `/track-order` → refresh → order still loads (needs the backend PR deployed to a shared environment).
- [ ] Independent review by ChatGPT, per our dual-LLM process (round 2).

Depends on supermerch-backend#72 merging/deploying first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)