### PR TITLE
Add GA4, Meta Pixel, and Microsoft Clarity analytics tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,13 @@ CLOUDINARY_CLOUD_NAME=XYZ
 CLOUDINARY_API_KEY=XYZ
 CLOUDINARY_API_SECRET=XY
 
+# Analytics — all optional. Each is a no-op (script never loads) if unset.
+# GA4 Measurement ID: GA4 Admin > Data Streams > (your web stream) > Measurement ID (format G-XXXXXXX)
+VITE_GA_MEASUREMENT_ID=
+# Meta Pixel ID: Meta Events Manager > Data Sources > your Pixel > Pixel ID (numeric)
+VITE_META_PIXEL_ID=
+# Microsoft Clarity Project ID: clarity.microsoft.com > your project > Settings > Setup > Project ID
+VITE_CLARITY_PROJECT_ID=
 
 #This project runs on Vite, which requires env variables to be prefixed with VITE_.
 #the previous REACT_APP_GOOGLE_CLIENT_ID variable was not being read at runtime.

--- a/index.html
+++ b/index.html
@@ -80,29 +80,15 @@
 
   <!-- Stylesheets -->
 </head>
-<!-- Google tag (gtag.js) — disabled on localhost dev -->
-<script>
-  (function () {
-    const isLocalhost =
-      location.hostname === "localhost" ||
-      location.hostname === "127.0.0.1" ||
-      location.hostname === "::1";
-
-    if (isLocalhost) return;
-
-    window.dataLayer = window.dataLayer || [];
-    window.gtag = function () {
-      dataLayer.push(arguments);
-    };
-    window.gtag("js", new Date());
-    window.gtag("config", "G-RYN804XC9M");
-
-    const script = document.createElement("script");
-    script.async = true;
-    script.src = "https://www.googletagmanager.com/gtag/js?id=G-RYN804XC9M";
-    document.head.appendChild(script);
-  })();
-</script>
+<!-- GA4 / Meta Pixel / Clarity are initialized from src/lib/analytics.js
+     (called in main.jsx), driven by VITE_GA_MEASUREMENT_ID /
+     VITE_META_PIXEL_ID / VITE_CLARITY_PROJECT_ID. Each is a no-op if its
+     env var isn't set. See PR description for what to configure in Vercel.
+     NOTE: this used to be a hardcoded gtag snippet with measurement ID
+     G-RYN804XC9M (present since initial project scaffold) — that ID has
+     not been verified as a real property belonging to this business and
+     was not env-driven, so it has been replaced rather than carried
+     forward as a default. -->
 <!--Start of Tawk.to Script-->
 <!-- <script type="text/javascript">
     var Tawk_API = Tawk_API || {},

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ import { HelmetProvider } from "react-helmet-async";
 import ChatWidget from "./components/Chat/ChatWidget";
 import SitePopups from "./components/Home/SitePopups";
 import RouteSeo from "./components/Common/RouteSeo";
+import CookieConsentBanner from "./components/Common/CookieConsentBanner";
 import { trackPageView } from "./lib/analytics";
 
 const CategoryPage = lazy(() => import("./pages/CategoryPage"));
@@ -184,6 +185,7 @@ const App = () => {
       {/* <Sidebar /> */}
       <ChatWidget />
       <SitePopups />
+      <CookieConsentBanner />
       <Footer />
     </>
   );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ import { HelmetProvider } from "react-helmet-async";
 import ChatWidget from "./components/Chat/ChatWidget";
 import SitePopups from "./components/Home/SitePopups";
 import RouteSeo from "./components/Common/RouteSeo";
+import { trackPageView } from "./lib/analytics";
 
 const CategoryPage = lazy(() => import("./pages/CategoryPage"));
 const ShopPage = lazy(() => import("./pages/ShopPage"));
@@ -76,6 +77,12 @@ const App = () => {
       }
     }
   }, [location.pathname]);
+
+  // Track SPA page views — route changes here don't trigger a real browser
+  // navigation, so GA4/Meta Pixel wouldn't otherwise see them.
+  useEffect(() => {
+    trackPageView(`${location.pathname}${location.search}`);
+  }, [location.pathname, location.search]);
 
   const handleCouponClick = () => {
     // Ensure we are on Home so the modal listener exists, then trigger it

--- a/src/__tests__/analytics.test.js
+++ b/src/__tests__/analytics.test.js
@@ -1,0 +1,168 @@
+// @vitest-environment jsdom
+
+/**
+ * src/lib/analytics.js — provider loading, consent gating, and dedup guards.
+ *
+ * Each test dynamically re-imports the module after `vi.resetModules()` so
+ * that the module-level `initialized` flag and the env-var consts (which are
+ * read once at import time) are fresh for every test.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const setNonLocalHostname = () => {
+  Object.defineProperty(window, "location", {
+    value: new URL("https://www.supermerch.com.au/"),
+    writable: true,
+    configurable: true,
+  });
+};
+
+const importFreshAnalytics = () => import("../lib/analytics.js");
+
+beforeEach(() => {
+  vi.resetModules();
+  localStorage.clear();
+  document.head.innerHTML = "";
+  delete window.gtag;
+  delete window.fbq;
+  delete window._fbq;
+  delete window.clarity;
+  delete window.dataLayer;
+  setNonLocalHostname();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("(a) no env vars configured", () => {
+  it("injects no script tags at all, even once consent is granted", async () => {
+    const analytics = await importFreshAnalytics();
+
+    analytics.grantAnalyticsConsent();
+
+    expect(document.querySelectorAll("script").length).toBe(0);
+    expect(window.gtag).toBeUndefined();
+    expect(window.fbq).toBeUndefined();
+    expect(window.clarity).toBeUndefined();
+  });
+
+  it("initAnalytics() on startup is also a no-op with no env vars", async () => {
+    const analytics = await importFreshAnalytics();
+    localStorage.setItem(analytics.CONSENT_STORAGE_KEY, analytics.CONSENT_ACCEPTED);
+
+    analytics.initAnalytics();
+
+    expect(document.querySelectorAll("script").length).toBe(0);
+  });
+});
+
+describe("(b) each provider initializes exactly once", () => {
+  beforeEach(() => {
+    vi.stubEnv("VITE_GA_MEASUREMENT_ID", "G-TEST123");
+    vi.stubEnv("VITE_META_PIXEL_ID", "1234567890");
+    vi.stubEnv("VITE_CLARITY_PROJECT_ID", "abcdef");
+  });
+
+  it("survives repeated grantAnalyticsConsent() calls (e.g. re-renders)", async () => {
+    const analytics = await importFreshAnalytics();
+
+    analytics.grantAnalyticsConsent();
+    analytics.grantAnalyticsConsent();
+    analytics.grantAnalyticsConsent();
+
+    expect(document.querySelectorAll('script[src*="googletagmanager.com"]').length).toBe(1);
+    expect(document.querySelectorAll('script[src*="connect.facebook.net"]').length).toBe(1);
+    expect(document.querySelectorAll('script[src*="clarity.ms"]').length).toBe(1);
+  });
+
+  it("survives a mix of initAnalytics() and grantAnalyticsConsent() calls", async () => {
+    const analytics = await importFreshAnalytics();
+    localStorage.setItem(analytics.CONSENT_STORAGE_KEY, analytics.CONSENT_ACCEPTED);
+
+    analytics.initAnalytics(); // startup, consent already on file
+    analytics.initAnalytics(); // e.g. StrictMode double-invoke
+    analytics.grantAnalyticsConsent(); // shopper re-clicks Accept via preferences link
+
+    expect(document.querySelectorAll('script[src*="googletagmanager.com"]').length).toBe(1);
+    expect(document.querySelectorAll('script[src*="connect.facebook.net"]').length).toBe(1);
+    expect(document.querySelectorAll('script[src*="clarity.ms"]').length).toBe(1);
+  });
+});
+
+describe("(f) declining consent prevents all three providers from loading", () => {
+  beforeEach(() => {
+    vi.stubEnv("VITE_GA_MEASUREMENT_ID", "G-TEST123");
+    vi.stubEnv("VITE_META_PIXEL_ID", "1234567890");
+    vi.stubEnv("VITE_CLARITY_PROJECT_ID", "abcdef");
+  });
+
+  it("declineAnalyticsConsent() never injects any script", async () => {
+    const analytics = await importFreshAnalytics();
+
+    analytics.declineAnalyticsConsent();
+
+    expect(document.querySelectorAll("script").length).toBe(0);
+    expect(window.gtag).toBeUndefined();
+    expect(window.fbq).toBeUndefined();
+    expect(window.clarity).toBeUndefined();
+    expect(localStorage.getItem(analytics.CONSENT_STORAGE_KEY)).toBe(
+      analytics.CONSENT_DECLINED,
+    );
+  });
+
+  it("a stored decline from a previous visit keeps initAnalytics() a no-op on startup", async () => {
+    const analytics = await importFreshAnalytics();
+    localStorage.setItem(analytics.CONSENT_STORAGE_KEY, analytics.CONSENT_DECLINED);
+
+    analytics.initAnalytics();
+
+    expect(document.querySelectorAll("script").length).toBe(0);
+    expect(window.gtag).toBeUndefined();
+    expect(window.fbq).toBeUndefined();
+    expect(window.clarity).toBeUndefined();
+  });
+
+  it("a stored accept from a previous visit loads providers automatically on startup", async () => {
+    const analytics = await importFreshAnalytics();
+    localStorage.setItem(analytics.CONSENT_STORAGE_KEY, analytics.CONSENT_ACCEPTED);
+
+    analytics.initAnalytics();
+
+    expect(document.querySelectorAll('script[src*="googletagmanager.com"]').length).toBe(1);
+    expect(window.gtag).toBeTypeOf("function");
+  });
+});
+
+describe("Meta Pixel initial PageView de-duplication", () => {
+  it("initMetaPixel does not itself queue a PageView event on init", async () => {
+    vi.stubEnv("VITE_META_PIXEL_ID", "1234567890");
+    const analytics = await importFreshAnalytics();
+
+    analytics.grantAnalyticsConsent();
+
+    // The fbq stub queues calls (real fbevents.js script never actually
+    // executes in jsdom), so we can inspect exactly what was queued.
+    const queuedTrackPageViews = window.fbq.queue.filter(
+      (args) => args[0] === "track" && args[1] === "PageView",
+    );
+    expect(queuedTrackPageViews.length).toBe(0);
+
+    const queuedInits = window.fbq.queue.filter((args) => args[0] === "init");
+    expect(queuedInits.length).toBe(1);
+  });
+
+  it("trackPageView is the only thing that queues a PageView, and does so exactly once per call", async () => {
+    vi.stubEnv("VITE_META_PIXEL_ID", "1234567890");
+    const analytics = await importFreshAnalytics();
+    analytics.grantAnalyticsConsent();
+
+    analytics.trackPageView("/some-page");
+
+    const queuedTrackPageViews = window.fbq.queue.filter(
+      (args) => args[0] === "track" && args[1] === "PageView",
+    );
+    expect(queuedTrackPageViews.length).toBe(1);
+  });
+});

--- a/src/__tests__/analytics.test.js
+++ b/src/__tests__/analytics.test.js
@@ -136,33 +136,151 @@ describe("(f) declining consent prevents all three providers from loading", () =
 });
 
 describe("Meta Pixel initial PageView de-duplication", () => {
-  it("initMetaPixel does not itself queue a PageView event on init", async () => {
+  it("initMetaPixel does not itself queue a PageView event separate from the fix-#2 auto-fire", async () => {
     vi.stubEnv("VITE_META_PIXEL_ID", "1234567890");
     const analytics = await importFreshAnalytics();
 
     analytics.grantAnalyticsConsent();
 
-    // The fbq stub queues calls (real fbevents.js script never actually
-    // executes in jsdom), so we can inspect exactly what was queued.
+    // grantAnalyticsConsent() itself auto-fires exactly one PageView for the
+    // current page now (fix #2, tested in detail below) — initMetaPixel must
+    // not add a *second* one on top of that.
     const queuedTrackPageViews = window.fbq.queue.filter(
       (args) => args[0] === "track" && args[1] === "PageView",
     );
-    expect(queuedTrackPageViews.length).toBe(0);
+    expect(queuedTrackPageViews.length).toBe(1);
 
     const queuedInits = window.fbq.queue.filter((args) => args[0] === "init");
     expect(queuedInits.length).toBe(1);
   });
 
-  it("trackPageView is the only thing that queues a PageView, and does so exactly once per call", async () => {
+  it("trackPageView queues exactly one further PageView per explicit call", async () => {
     vi.stubEnv("VITE_META_PIXEL_ID", "1234567890");
     const analytics = await importFreshAnalytics();
-    analytics.grantAnalyticsConsent();
+    analytics.grantAnalyticsConsent(); // auto-fires 1 PageView (fix #2)
 
     analytics.trackPageView("/some-page");
 
     const queuedTrackPageViews = window.fbq.queue.filter(
       (args) => args[0] === "track" && args[1] === "PageView",
     );
-    expect(queuedTrackPageViews.length).toBe(1);
+    expect(queuedTrackPageViews.length).toBe(2); // 1 auto-fired + 1 explicit
+  });
+});
+
+describe("(g) consent lifecycle — entry-page pageview, live decline, forced reload", () => {
+  beforeEach(() => {
+    vi.stubEnv("VITE_GA_MEASUREMENT_ID", "G-TEST123");
+    vi.stubEnv("VITE_META_PIXEL_ID", "1234567890");
+    vi.stubEnv("VITE_CLARITY_PROJECT_ID", "abcdef");
+  });
+
+  it("first visit -> Accept fires exactly one page_view/PageView for the current page", async () => {
+    const analytics = await importFreshAnalytics();
+
+    // Simulates App.jsx's route-tracking effect firing on initial mount,
+    // before any consent decision exists — must be a silent no-op (fix 1b),
+    // since nothing has loaded yet and consent isn't "accepted".
+    analytics.trackPageView("/entry-page");
+
+    analytics.grantAnalyticsConsent(); // shopper clicks "Accept All"
+
+    const gaPageViews = window.dataLayer.filter(
+      (args) => args[0] === "event" && args[1] === "page_view",
+    );
+    const metaPageViews = window.fbq.queue.filter(
+      (args) => args[0] === "track" && args[1] === "PageView",
+    );
+    expect(gaPageViews.length).toBe(1);
+    expect(metaPageViews.length).toBe(1);
+  });
+
+  it("returning visitor with stored acceptance gets exactly one page view on startup, not two", async () => {
+    const analytics = await importFreshAnalytics();
+    localStorage.setItem(analytics.CONSENT_STORAGE_KEY, analytics.CONSENT_ACCEPTED);
+
+    analytics.initAnalytics(); // main.jsx, module-load time — loads providers
+    analytics.trackPageView("/entry-page"); // App.jsx's normal mount effect
+
+    const gaPageViews = window.dataLayer.filter(
+      (args) => args[0] === "event" && args[1] === "page_view",
+    );
+    const metaPageViews = window.fbq.queue.filter(
+      (args) => args[0] === "track" && args[1] === "PageView",
+    );
+    // Must be exactly one — initAnalytics() itself must NOT auto-fire a
+    // pageview (that would double-count alongside App.jsx's own effect).
+    expect(gaPageViews.length).toBe(1);
+    expect(metaPageViews.length).toBe(1);
+  });
+
+  it("re-affirming Accept via preferences (already loaded at startup) does not add an extra pageview", async () => {
+    const analytics = await importFreshAnalytics();
+    localStorage.setItem(analytics.CONSENT_STORAGE_KEY, analytics.CONSENT_ACCEPTED);
+
+    analytics.initAnalytics(); // startup already loaded providers
+    analytics.grantAnalyticsConsent(); // shopper re-clicks Accept in preferences
+
+    const metaPageViews = window.fbq.queue.filter(
+      (args) => args[0] === "track" && args[1] === "PageView",
+    );
+    expect(metaPageViews.length).toBe(0);
+  });
+
+  it("Accept -> later Decline makes every track* helper an immediate no-op, without a reload", async () => {
+    const analytics = await importFreshAnalytics();
+    analytics.grantAnalyticsConsent();
+
+    // Sanity check: tracking works while consent is accepted.
+    window.dataLayer.length = 0;
+    window.fbq.queue.length = 0;
+    analytics.trackAddToCart({ id: 1, name: "Mug", price: 10, quantity: 1 });
+    expect(
+      window.dataLayer.some((args) => args[0] === "event" && args[1] === "add_to_cart"),
+    ).toBe(true);
+
+    // Stub reload so declining doesn't try to actually navigate jsdom.
+    window.location.reload = vi.fn();
+    analytics.declineAnalyticsConsent();
+
+    window.dataLayer.length = 0;
+    window.fbq.queue.length = 0;
+    analytics.trackPageView("/somewhere");
+    analytics.trackAddToCart({ id: 1, name: "Mug", price: 10, quantity: 1 });
+    analytics.trackCheckoutStarted({ value: 10 });
+    analytics.trackPurchase({ transactionId: "t1", value: 10 });
+
+    // Every helper checked hasAnalyticsConsent() up front and no-op'd —
+    // nothing new was pushed to gtag's dataLayer or fbq's queue, even
+    // though window.gtag/window.fbq are still technically defined.
+    expect(window.dataLayer.length).toBe(0);
+    expect(window.fbq.queue.length).toBe(0);
+    expect(analytics.hasAnalyticsConsent()).toBe(false);
+  });
+
+  it("Accept -> Decline triggers a full page reload when providers were already loaded", async () => {
+    const analytics = await importFreshAnalytics();
+    analytics.grantAnalyticsConsent();
+
+    const reloadSpy = vi.fn();
+    window.location.reload = reloadSpy;
+
+    analytics.declineAnalyticsConsent();
+
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem(analytics.CONSENT_STORAGE_KEY)).toBe(
+      analytics.CONSENT_DECLINED,
+    );
+  });
+
+  it("declining before providers ever loaded does not attempt a reload", async () => {
+    const analytics = await importFreshAnalytics();
+
+    const reloadSpy = vi.fn();
+    window.location.reload = reloadSpy;
+
+    analytics.declineAnalyticsConsent();
+
+    expect(reloadSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/analyticsMiddleware.test.js
+++ b/src/__tests__/analyticsMiddleware.test.js
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+
+/**
+ * src/redux/middleware/analyticsMiddleware.js
+ *
+ * Proves that dispatching the real, shared `cart/addToCart` redux action
+ * (the same action creator every add-to-cart call site in the app uses)
+ * results in exactly one trackAddToCart() call with the correct product
+ * id/name/price/quantity mapped from the action payload.
+ */
+
+import { configureStore } from "@reduxjs/toolkit";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const trackAddToCartMock = vi.fn();
+
+vi.mock("../lib/analytics", () => ({
+  trackAddToCart: (...args) => trackAddToCartMock(...args),
+}));
+
+import cartReducer, { addToCart } from "../redux/slices/cartSlice";
+import { analyticsMiddleware } from "../redux/middleware/analyticsMiddleware";
+
+const buildStore = () =>
+  configureStore({
+    reducer: { cart: cartReducer },
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware().concat(analyticsMiddleware),
+  });
+
+beforeEach(() => {
+  trackAddToCartMock.mockClear();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("(g) analyticsMiddleware add-to-cart payload", () => {
+  it("fires exactly once with correct id/name/price/quantity for a regular product", () => {
+    const store = buildStore();
+
+    store.dispatch(
+      addToCart({
+        id: "prod-42",
+        name: "Custom Tote Bag",
+        price: 12.5,
+        quantity: 3,
+        userEmail: "shopper@example.com",
+      }),
+    );
+
+    expect(trackAddToCartMock).toHaveBeenCalledTimes(1);
+    expect(trackAddToCartMock).toHaveBeenCalledWith({
+      id: "prod-42",
+      name: "Custom Tote Bag",
+      price: 12.5,
+      quantity: 3,
+      currency: "AUD",
+    });
+  });
+
+  it("falls back to the deal name and multiplier-as-quantity for a deal line item", () => {
+    const store = buildStore();
+
+    store.dispatch(
+      addToCart({
+        id: "deal-7",
+        itemType: "deal",
+        deal: { name: "3-Piece Starter Pack" },
+        price: 49.99,
+        multiplier: 2,
+        userEmail: "shopper@example.com",
+      }),
+    );
+
+    expect(trackAddToCartMock).toHaveBeenCalledTimes(1);
+    expect(trackAddToCartMock).toHaveBeenCalledWith({
+      id: "deal-7",
+      name: "3-Piece Starter Pack",
+      price: 49.99,
+      quantity: 2,
+      currency: "AUD",
+    });
+  });
+
+  it("does not fire trackAddToCart for unrelated cart actions", () => {
+    const store = buildStore();
+
+    store.dispatch({ type: "cart/removeFromCart", payload: { id: "prod-42" } });
+
+    expect(trackAddToCartMock).not.toHaveBeenCalled();
+  });
+
+  it("fires once per dispatch across multiple add-to-cart calls (no duplication, no missed calls)", () => {
+    const store = buildStore();
+
+    store.dispatch(addToCart({ id: "a", name: "Pen", price: 1, quantity: 10 }));
+    store.dispatch(addToCart({ id: "b", name: "Mug", price: 8, quantity: 1 }));
+
+    expect(trackAddToCartMock).toHaveBeenCalledTimes(2);
+    expect(trackAddToCartMock).toHaveBeenNthCalledWith(1, {
+      id: "a",
+      name: "Pen",
+      price: 1,
+      quantity: 10,
+      currency: "AUD",
+    });
+    expect(trackAddToCartMock).toHaveBeenNthCalledWith(2, {
+      id: "b",
+      name: "Mug",
+      price: 8,
+      quantity: 1,
+      currency: "AUD",
+    });
+  });
+});

--- a/src/__tests__/appPageView.test.jsx
+++ b/src/__tests__/appPageView.test.jsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+
+/**
+ * src/App.jsx — route-tracking is the single source of truth for PageView.
+ *
+ * (c) Proves exactly one trackPageView() call fires on initial load, and
+ * exactly one more per subsequent client-side route navigation — no
+ * duplicates. (analytics.test.js separately proves initMetaPixel() itself
+ * no longer queues a PageView on init, which is what used to double-count
+ * the very first page load; this test proves the App-level effect that is
+ * now the sole source is itself dedup-safe.)
+ */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import PropTypes from "prop-types";
+import { Provider } from "react-redux";
+import { MemoryRouter, useNavigate } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Keep the tree small and dependency-free: mock every heavy/global child so
+// this test exercises only App's own route-tracking effect.
+vi.mock("../components/Home/Navbar", () => ({ default: () => null }));
+vi.mock("../components/Home/Footer", () => ({ default: () => null }));
+vi.mock("../components/Chat/ChatWidget", () => ({ default: () => null }));
+vi.mock("../components/Home/SitePopups", () => ({ default: () => null }));
+vi.mock("../components/Common/RouteSeo", () => ({ default: () => null }));
+vi.mock("../components/Common/CookieConsentBanner", () => ({ default: () => null }));
+vi.mock("../pages/Home/Home", () => ({ default: () => <div>HomePage</div> }));
+vi.mock("../pages/ProductPageResolver", () => ({
+  default: () => <div>ProductPage</div>,
+}));
+
+const trackPageViewMock = vi.fn();
+vi.mock("../lib/analytics", () => ({
+  trackPageView: (...args) => trackPageViewMock(...args),
+}));
+
+import App from "../App";
+import { AuthContext } from "../context/AuthContext";
+import { store } from "../redux/store";
+
+afterEach(() => {
+  cleanup();
+  trackPageViewMock.mockClear();
+});
+
+const NavigateOnClick = ({ to }) => {
+  const navigate = useNavigate();
+  return (
+    <button type="button" onClick={() => navigate(to)}>
+      go-to-{to}
+    </button>
+  );
+};
+
+NavigateOnClick.propTypes = {
+  to: PropTypes.string.isRequired,
+};
+
+const renderApp = (initialEntries) =>
+  render(
+    <AuthContext.Provider value={{ token: null }}>
+      <Provider store={store}>
+        <MemoryRouter initialEntries={initialEntries}>
+          <NavigateOnClick to="/product/1" />
+          <App />
+        </MemoryRouter>
+      </Provider>
+    </AuthContext.Provider>,
+  );
+
+describe("App PageView tracking", () => {
+  it("fires exactly one trackPageView on initial mount", () => {
+    renderApp(["/"]);
+
+    expect(screen.getByText("HomePage")).toBeInTheDocument();
+    expect(trackPageViewMock).toHaveBeenCalledTimes(1);
+    expect(trackPageViewMock).toHaveBeenCalledWith("/");
+  });
+
+  it("fires exactly one additional trackPageView per subsequent navigation, no duplicates", () => {
+    renderApp(["/"]);
+    expect(trackPageViewMock).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByText("go-to-/product/1"));
+
+    expect(screen.getByText("ProductPage")).toBeInTheDocument();
+    expect(trackPageViewMock).toHaveBeenCalledTimes(2);
+    expect(trackPageViewMock).toHaveBeenNthCalledWith(2, "/product/1");
+  });
+});

--- a/src/__tests__/checkoutPurchaseTracking.test.jsx
+++ b/src/__tests__/checkoutPurchaseTracking.test.jsx
@@ -1,0 +1,181 @@
+// @vitest-environment jsdom
+
+/**
+ * src/components/checkout/Checkout.jsx — purchase-tracking must not be
+ * gated by the unrelated loadUserOrder() account/order refresh call.
+ *
+ * Regression coverage for the HIGH-severity bug: previously
+ * `trackPurchase()` ran only after `await loadUserOrder()` resolved, so a
+ * failure in that unrelated refresh call silently dropped a real, paid
+ * conversion. These tests exercise the actual post-Stripe-redirect flow
+ * (Checkout mounts with `location.state.paymentSuccess`, which triggers
+ * `handlePaymentSuccess()`):
+ *
+ * (d) a successful checkout still records the purchase event even when
+ *     loadUserOrder() rejects.
+ * (e) a failed checkout (backend rejects the order) never records a
+ *     purchase event.
+ */
+
+import { cleanup, render, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import axios from "axios";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { configureStore } from "@reduxjs/toolkit";
+
+vi.mock("axios");
+
+const trackPurchaseMock = vi.fn();
+const trackCheckoutStartedMock = vi.fn();
+vi.mock("@/lib/analytics", () => ({
+  trackPurchase: (...args) => trackPurchaseMock(...args),
+  trackCheckoutStarted: (...args) => trackCheckoutStartedMock(...args),
+}));
+
+// The step components pull in a lot of unrelated UI/markup we don't need to
+// exercise the mount-time handlePaymentSuccess() effect under test.
+vi.mock("../components/checkout/CheckoutSteps/CustomerStep", () => ({ default: () => null }));
+vi.mock("../components/checkout/CheckoutSteps/ShippingStep", () => ({ default: () => null }));
+vi.mock("../components/checkout/CheckoutSteps/BillingStep", () => ({ default: () => null }));
+vi.mock("../components/checkout/CheckoutSteps/PaymentStep", () => ({ default: () => null }));
+vi.mock("../components/checkout/CheckoutSteps/OrderSummarySidebar", () => ({ default: () => null }));
+
+import Checkout from "../components/checkout/Checkout";
+import { AuthContext } from "../context/AuthContext";
+import { AppContext } from "../context/AppContext";
+import { ProductsContext } from "../context/ProductsContext";
+import cartReducer from "../redux/slices/cartSlice";
+
+const buildStore = () => configureStore({ reducer: { cart: cartReducer } });
+
+const SESSION_ID = "cs_test_123";
+
+const renderCheckout = ({ loadUserOrder }) => {
+  const store = buildStore();
+  return render(
+    <AuthContext.Provider
+      value={{
+        token: null,
+        setToken: vi.fn(),
+        addressData: {},
+        shippingAddressData: {},
+        userData: null,
+        loadUserOrder,
+      }}
+    >
+      <AppContext.Provider
+        value={{
+          backendUrl: "https://backend.test",
+          openLoginModal: false,
+          setOpenLoginModal: vi.fn(),
+          shippingCharges: 0,
+          setupFee: 0,
+          gstCharges: 0,
+        }}
+      >
+        <ProductsContext.Provider value={{ totalDiscount: {} }}>
+          <Provider store={store}>
+            <MemoryRouter
+              initialEntries={[
+                {
+                  pathname: "/checkout",
+                  state: { paymentSuccess: true, sessionId: SESSION_ID },
+                },
+              ]}
+            >
+              <Checkout />
+            </MemoryRouter>
+          </Provider>
+        </ProductsContext.Provider>
+      </AppContext.Provider>
+    </AuthContext.Provider>,
+  );
+};
+
+beforeEach(() => {
+  localStorage.clear();
+  sessionStorage.clear();
+  trackPurchaseMock.mockClear();
+  trackCheckoutStartedMock.mockClear();
+  localStorage.setItem(
+    "pendingCheckoutData",
+    JSON.stringify({ total: 149.95, products: [] }),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("(d) purchase tracking survives a failed order refresh", () => {
+  it("records the purchase event even when loadUserOrder() rejects", async () => {
+    axios.post.mockResolvedValueOnce({
+      data: {
+        checkout: {
+          orderId: "ORD-1001",
+          _id: "mongo-id-1",
+          total: 149.95,
+        },
+      },
+    });
+    const loadUserOrder = vi.fn().mockRejectedValue(new Error("refresh failed"));
+
+    renderCheckout({ loadUserOrder });
+
+    await waitFor(() => expect(trackPurchaseMock).toHaveBeenCalledTimes(1));
+    expect(trackPurchaseMock).toHaveBeenCalledWith({
+      transactionId: "ORD-1001",
+      value: 149.95,
+      currency: "AUD",
+    });
+
+    // The refresh call still happens (for its own account-UI purpose) —
+    // it just must not gate analytics, which the assertion above proves.
+    await waitFor(() => expect(loadUserOrder).toHaveBeenCalledTimes(1));
+  });
+
+  it("records the purchase event when loadUserOrder() succeeds too (baseline)", async () => {
+    axios.post.mockResolvedValueOnce({
+      data: {
+        checkout: {
+          orderId: "ORD-1002",
+          _id: "mongo-id-2",
+          total: 75,
+        },
+      },
+    });
+    const loadUserOrder = vi.fn().mockResolvedValue(undefined);
+
+    renderCheckout({ loadUserOrder });
+
+    await waitFor(() => expect(trackPurchaseMock).toHaveBeenCalledTimes(1));
+    expect(trackPurchaseMock).toHaveBeenCalledWith({
+      transactionId: "ORD-1002",
+      value: 75,
+      currency: "AUD",
+    });
+  });
+});
+
+describe("(e) a failed checkout never records a purchase event", () => {
+  it("does not call trackPurchase when the checkout API call itself rejects", async () => {
+    axios.post.mockRejectedValueOnce({
+      response: { data: { message: "Payment declined" } },
+    });
+    const loadUserOrder = vi.fn().mockResolvedValue(undefined);
+
+    renderCheckout({ loadUserOrder });
+
+    await waitFor(() => expect(axios.post).toHaveBeenCalledTimes(1));
+    // Let the rejected promise's .catch() handler finish running.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(trackPurchaseMock).not.toHaveBeenCalled();
+    expect(loadUserOrder).not.toHaveBeenCalled();
+    // Failure path never clears the pending checkout data (only success does).
+    expect(localStorage.getItem("pendingCheckoutData")).not.toBeNull();
+  });
+});

--- a/src/components/Common/CookieConsentBanner.jsx
+++ b/src/components/Common/CookieConsentBanner.jsx
@@ -1,0 +1,72 @@
+// src/components/Common/CookieConsentBanner.jsx
+//
+// Mounts the (previously dead-code) CookieModal for real and wires its
+// Accept/Decline buttons to actually gate GA4/Meta Pixel/Clarity loading.
+//
+// Behaviour:
+// - First visit (no stored decision): shows the banner. Declining or simply
+//   closing it (X / backdrop / Escape) leaves analytics off — GA4/Meta
+//   Pixel/Clarity never load — and does NOT persist a decision, so the
+//   shopper is asked again on their next visit. Explicitly clicking
+//   "Decline All" persists that choice so we stop asking.
+// - Accepting persists the choice and loads the providers immediately.
+// - Once a decision is stored, the banner does not show again automatically.
+//   A "Cookie Preferences" link/button anywhere in the app can dispatch the
+//   `openCookiePreferences` window event to reopen it (see Footer.jsx).
+//
+// This is a dismissible banner only — it never blocks browsing, cart, or
+// checkout; it only gates the three analytics providers above.
+
+import { useEffect, useState } from "react";
+import CookieModal from "../Home/Modals/CookieModal";
+import {
+  getStoredConsent,
+  grantAnalyticsConsent,
+  declineAnalyticsConsent,
+} from "@/lib/analytics";
+
+const CookieConsentBanner = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    // No stored decision yet -> prompt. Already decided -> stay hidden.
+    if (getStoredConsent() === null) {
+      setIsOpen(true);
+    }
+  }, []);
+
+  // Lets any part of the app (e.g. a footer "Cookie Preferences" link)
+  // reopen the banner so the shopper can change their mind later.
+  useEffect(() => {
+    const handleReopen = () => setIsOpen(true);
+    window.addEventListener("openCookiePreferences", handleReopen);
+    return () => window.removeEventListener("openCookiePreferences", handleReopen);
+  }, []);
+
+  const handleAccept = () => {
+    grantAnalyticsConsent();
+    setIsOpen(false);
+  };
+
+  const handleDecline = () => {
+    declineAnalyticsConsent();
+    setIsOpen(false);
+  };
+
+  const handleClose = () => {
+    // Dismissing without an explicit choice does not persist a decision —
+    // analytics stays off (default) and we'll ask again next visit.
+    setIsOpen(false);
+  };
+
+  return (
+    <CookieModal
+      isOpen={isOpen}
+      onClose={handleClose}
+      onAccept={handleAccept}
+      onDecline={handleDecline}
+    />
+  );
+};
+
+export default CookieConsentBanner;

--- a/src/components/Home/Footer.jsx
+++ b/src/components/Home/Footer.jsx
@@ -297,6 +297,15 @@ const Footer = () => {
               >
                 Terms of Service
               </Link>
+              <button
+                type="button"
+                onClick={() =>
+                  window.dispatchEvent(new CustomEvent("openCookiePreferences"))
+                }
+                className="text-white/80 hover:text-white transition-colors"
+              >
+                Cookie Preferences
+              </button>
             </div>
           </div>
         </div>

--- a/src/components/Home/Modals/CookieModal.jsx
+++ b/src/components/Home/Modals/CookieModal.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from "react";
 import PropTypes from "prop-types";
+import { Link } from "react-router-dom";
 
 const CookieModal = ({ isOpen, onClose, onAccept, onDecline }) => {
   const handleBackdropClick = (e) => {
@@ -48,9 +49,16 @@ const CookieModal = ({ isOpen, onClose, onAccept, onDecline }) => {
                   Cookie Preferences
                 </h3>
                 <p className="text-white text-base leading-relaxed mb-3">
-                  We use cookies to enhance your browsing experience, provide
-                  personalized content, and analyze our traffic. By continuing
-                  to use our site, you consent to our use of cookies.
+                  We&rsquo;d like to use Google Analytics, Meta Pixel, and
+                  Microsoft Clarity to understand how visitors use our site.
+                  These stay off unless you click &ldquo;Accept All&rdquo;
+                  &mdash; browsing our site alone doesn&rsquo;t turn them on.
+                  See our{" "}
+                  <Link to="/privacy" className="underline hover:text-gray-200">
+                    Privacy Policy
+                  </Link>{" "}
+                  for details, or click &ldquo;Decline All&rdquo; to keep them
+                  off.
                 </p>
               </div>
             </div>

--- a/src/components/checkout/Checkout.jsx
+++ b/src/components/checkout/Checkout.jsx
@@ -215,17 +215,36 @@ const Checkout = () => {
       });
       dispatch(clearCart());
       toast.success("Order placed successfully!");
-      await loadUserOrder();
 
       const createdOrder = response.data?.checkout;
       const orderId =
         createdOrder?.orderId || createdOrder?.orderNumber || createdOrder?._id;
 
+      // Fire the purchase conversion event immediately once the order has
+      // been created and payment confirmed by the backend (the axios.post
+      // above already resolved successfully). This must NOT be gated on
+      // loadUserOrder() below — that call refreshes the account/order list
+      // for the UI and is unrelated to whether the purchase actually
+      // happened. If it fails, the customer has already been charged and
+      // the order already exists, so the conversion must still be recorded.
       trackPurchase({
         transactionId: orderId || sessionId,
         value: Number(createdOrder?.total ?? checkoutData?.total ?? 0),
         currency: "AUD",
       });
+
+      // Best-effort refresh of the user's order history for the account UI.
+      // Deliberately decoupled from analytics above — a failure here (e.g.
+      // a flaky refetch) must never suppress the purchase event or block
+      // the redirect to the order confirmation page below.
+      try {
+        await loadUserOrder();
+      } catch (refreshError) {
+        console.error(
+          "loadUserOrder failed after a successful checkout (order was still created and tracked):",
+          refreshError,
+        );
+      }
 
       // A guest (no account) has no other way to prove this order is theirs.
       // The backend hands this token out once, here, and requires it (or

--- a/src/components/checkout/Checkout.jsx
+++ b/src/components/checkout/Checkout.jsx
@@ -17,6 +17,7 @@ import CustomerStep from "./CheckoutSteps/CustomerStep";
 import OrderSummarySidebar from "./CheckoutSteps/OrderSummarySidebar";
 import PaymentStep from "./CheckoutSteps/PaymentStep";
 import ShippingStep from "./CheckoutSteps/ShippingStep";
+import { trackCheckoutStarted, trackPurchase } from "@/lib/analytics";
 
 const Checkout = () => {
   const navigate = useNavigate();
@@ -219,6 +220,12 @@ const Checkout = () => {
       const createdOrder = response.data?.checkout;
       const orderId =
         createdOrder?.orderId || createdOrder?.orderNumber || createdOrder?._id;
+
+      trackPurchase({
+        transactionId: orderId || sessionId,
+        value: Number(createdOrder?.total ?? checkoutData?.total ?? 0),
+        currency: "AUD",
+      });
 
       // A guest (no account) has no other way to prove this order is theirs.
       // The backend hands this token out once, here, and requires it (or
@@ -630,6 +637,12 @@ const Checkout = () => {
           : null,
         gstPercent: gstCharges,
       };
+
+      trackCheckoutStarted({
+        value: Number(total || 0),
+        currency: "AUD",
+        numItems: items.length,
+      });
 
       const resp = await axios.post(
         `${backendUrl}/api/create-checkout-session`,

--- a/src/lib/analytics.js
+++ b/src/lib/analytics.js
@@ -1,0 +1,190 @@
+// src/lib/analytics.js
+//
+// Thin wrapper around GA4 (gtag.js), Meta Pixel, and Microsoft Clarity.
+//
+// Design goals:
+// - Every provider is driven entirely by env vars (VITE_GA_MEASUREMENT_ID,
+//   VITE_META_PIXEL_ID, VITE_CLARITY_PROJECT_ID). If a var is unset, that
+//   provider is skipped entirely — no empty/invalid tags are ever injected.
+// - Scripts are loaded async and appended to <head> at runtime (never
+//   render-blocking), so they cannot slow down or break checkout.
+// - track* helpers are always safe to call from anywhere in the app, even
+//   before init runs or when a provider isn't configured — they just check
+//   for the relevant global (window.gtag / window.fbq) and no-op otherwise.
+// - Disabled on localhost/dev so local testing never pollutes real analytics
+//   data (matches the convention the previous inline GA snippet used).
+
+const GA_MEASUREMENT_ID = import.meta.env.VITE_GA_MEASUREMENT_ID;
+const META_PIXEL_ID = import.meta.env.VITE_META_PIXEL_ID;
+const CLARITY_PROJECT_ID = import.meta.env.VITE_CLARITY_PROJECT_ID;
+
+const isBrowser = typeof window !== "undefined";
+
+const isLocalDev = () => {
+  if (!isBrowser) return true;
+  const host = window.location.hostname;
+  return host === "localhost" || host === "127.0.0.1" || host === "::1";
+};
+
+let initialized = false;
+
+const appendScript = (src, extraAttrs = {}) => {
+  const script = document.createElement("script");
+  script.async = true;
+  script.src = src;
+  Object.entries(extraAttrs).forEach(([key, value]) => {
+    script.setAttribute(key, value);
+  });
+  document.head.appendChild(script);
+  return script;
+};
+
+const initGoogleAnalytics = () => {
+  if (!GA_MEASUREMENT_ID) return;
+
+  window.dataLayer = window.dataLayer || [];
+  window.gtag = function gtag(...args) {
+    window.dataLayer.push(args);
+  };
+  window.gtag("js", new Date());
+  // send_page_view is handled manually via trackPageView() so SPA route
+  // changes (which don't trigger a real navigation) are still recorded.
+  window.gtag("config", GA_MEASUREMENT_ID, { send_page_view: false });
+
+  appendScript(`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`);
+};
+
+const initMetaPixel = () => {
+  if (!META_PIXEL_ID) return;
+
+  const fbq = function (...args) {
+    if (fbq.callMethod) {
+      fbq.callMethod(...args);
+    } else {
+      fbq.queue.push(args);
+    }
+  };
+  if (!window.fbq) {
+    window.fbq = fbq;
+  }
+  window.fbq.push = window.fbq;
+  window.fbq.loaded = true;
+  window.fbq.version = "2.0";
+  window.fbq.queue = [];
+  window._fbq = window._fbq || window.fbq;
+
+  window.fbq("init", META_PIXEL_ID);
+  window.fbq("track", "PageView");
+
+  appendScript("https://connect.facebook.net/en_US/fbevents.js");
+};
+
+const initClarity = () => {
+  if (!CLARITY_PROJECT_ID) return;
+
+  window.clarity =
+    window.clarity ||
+    function (...args) {
+      (window.clarity.q = window.clarity.q || []).push(args);
+    };
+
+  appendScript(`https://www.clarity.ms/tag/${CLARITY_PROJECT_ID}`);
+};
+
+/** Call once on app startup. Safe to call multiple times (no-ops after the first). */
+export const initAnalytics = () => {
+  if (!isBrowser || initialized) return;
+  initialized = true;
+
+  if (isLocalDev()) return;
+
+  initGoogleAnalytics();
+  initMetaPixel();
+  initClarity();
+};
+
+/** Fire on every route change (SPA navigations don't trigger a browser page load). */
+export const trackPageView = (path) => {
+  if (!isBrowser) return;
+  if (window.gtag) {
+    window.gtag("event", "page_view", { page_path: path });
+  }
+  if (window.fbq) {
+    window.fbq("track", "PageView");
+  }
+};
+
+/**
+ * Fire when a shopper adds an item to their cart.
+ * @param {{ id: string|number, name: string, price: number, quantity: number, currency?: string }} item
+ */
+export const trackAddToCart = ({ id, name, price, quantity, currency = "AUD" }) => {
+  if (!isBrowser) return;
+  const value = Number(price || 0) * Number(quantity || 1);
+
+  if (window.gtag) {
+    window.gtag("event", "add_to_cart", {
+      currency,
+      value,
+      items: [
+        {
+          item_id: id,
+          item_name: name,
+          price: Number(price || 0),
+          quantity: Number(quantity || 1),
+        },
+      ],
+    });
+  }
+  if (window.fbq) {
+    window.fbq("track", "AddToCart", {
+      content_ids: [id],
+      content_name: name,
+      content_type: "product",
+      value,
+      currency,
+    });
+  }
+};
+
+/**
+ * Fire when a shopper submits the checkout form and is about to be handed
+ * off to Stripe (i.e. checkout has genuinely started).
+ * @param {{ value: number, currency?: string, numItems?: number }} data
+ */
+export const trackCheckoutStarted = ({ value, currency = "AUD", numItems }) => {
+  if (!isBrowser) return;
+
+  if (window.gtag) {
+    window.gtag("event", "begin_checkout", { currency, value: Number(value || 0) });
+  }
+  if (window.fbq) {
+    window.fbq("track", "InitiateCheckout", {
+      value: Number(value || 0),
+      currency,
+      num_items: numItems,
+    });
+  }
+};
+
+/**
+ * Fire once an order has been successfully created after Stripe confirms payment.
+ * @param {{ transactionId: string, value: number, currency?: string }} data
+ */
+export const trackPurchase = ({ transactionId, value, currency = "AUD" }) => {
+  if (!isBrowser) return;
+
+  if (window.gtag) {
+    window.gtag("event", "purchase", {
+      transaction_id: transactionId,
+      currency,
+      value: Number(value || 0),
+    });
+  }
+  if (window.fbq) {
+    window.fbq("track", "Purchase", {
+      value: Number(value || 0),
+      currency,
+    });
+  }
+};

--- a/src/lib/analytics.js
+++ b/src/lib/analytics.js
@@ -10,13 +10,19 @@
 //   render-blocking), so they never break checkout — though loading them
 //   still consumes bandwidth/CPU, so they are gated on consent (below).
 // - track* helpers are always safe to call from anywhere in the app, even
-//   before init runs or when a provider isn't configured — they just check
-//   for the relevant global (window.gtag / window.fbq) and no-op otherwise.
+//   before init runs or when a provider isn't configured — they check
+//   hasAnalyticsConsent() first (so they stop firing the instant consent is
+//   withdrawn, without relying on window.gtag/window.fbq happening to be
+//   gone) and then check for the relevant global before calling it.
 // - Disabled on localhost/dev so local testing never pollutes real analytics
 //   data (matches the convention the previous inline GA snippet used).
 // - Gated on cookie consent: none of GA4/Meta Pixel/Clarity load until the
 //   shopper explicitly accepts via the cookie banner (see CookieConsentBanner).
 //   Declining (or not yet deciding) means the scripts are never injected.
+// - Withdrawing consent after providers already loaded can't un-inject
+//   scripts or kill in-flight listeners from JS alone, so declineAnalyticsConsent()
+//   forces a full page reload in that case — the next load starts fresh,
+//   initAnalytics() sees the stored "declined" value, and nothing loads at all.
 
 const GA_MEASUREMENT_ID = import.meta.env.VITE_GA_MEASUREMENT_ID;
 const META_PIXEL_ID = import.meta.env.VITE_META_PIXEL_ID;
@@ -119,16 +125,22 @@ const initClarity = () => {
  * Actually injects the provider scripts. Guarded so it only ever runs once
  * per page load no matter how many times it's called (consent grant,
  * startup check, re-renders, etc).
+ *
+ * @returns {boolean} true iff THIS call is the one that transitioned
+ *   providers from not-loaded to loaded this session; false if they were
+ *   already loaded (or this isn't a browser). Callers use this to detect
+ *   the transition without needing a second module-level flag.
  */
 const loadProviders = () => {
-  if (!isBrowser || initialized) return;
+  if (!isBrowser || initialized) return false;
   initialized = true;
 
-  if (isLocalDev()) return;
+  if (isLocalDev()) return true;
 
   initGoogleAnalytics();
   initMetaPixel();
   initClarity();
+  return true;
 };
 
 /**
@@ -147,6 +159,15 @@ export const initAnalytics = () => {
  * Call when the shopper accepts the cookie banner. Persists the decision so
  * future visits don't re-prompt, and loads the providers for the first time
  * (no-ops if they're already loaded).
+ *
+ * If this call is what actually transitions providers from not-loaded to
+ * loaded (i.e. a first-time accept, not a re-affirming click from a
+ * returning visitor whose providers were already loaded at startup), we
+ * also emit one page_view/PageView for the page the shopper is already on.
+ * Without this, App.jsx's route-tracking effect already ran (and no-op'd,
+ * since there was no consent yet) before this moment, so GA4/Meta would
+ * otherwise never see a pageview for the entry page — only for whatever
+ * page the shopper navigates to next.
  */
 export const grantAnalyticsConsent = () => {
   if (!isBrowser) return;
@@ -156,22 +177,34 @@ export const grantAnalyticsConsent = () => {
     // localStorage unavailable (private browsing, etc.) — consent won't
     // persist across reloads, but scripts still load for this session.
   }
-  loadProviders();
+  const justLoaded = loadProviders();
+  if (justLoaded) {
+    trackPageView(`${window.location.pathname}${window.location.search}`);
+  }
 };
 
 /**
- * Call when the shopper declines the cookie banner. Persists the decision so
- * GA4/Meta Pixel/Clarity are never loaded on this device/browser — this only
- * flips a flag; it never calls loadProviders(), so no script tag is ever
- * injected and no provider global (gtag/fbq/clarity) is ever defined.
+ * Call when the shopper declines the cookie banner (including re-opening
+ * Cookie Preferences later and declining after having previously accepted).
+ * Persists the decision so GA4/Meta Pixel/Clarity are never loaded on this
+ * device/browser again — and, critically, if providers were ALREADY loaded
+ * this session (scripts injected, globals defined, listeners attached),
+ * flipping localStorage alone can't stop any of that from JS. So in that
+ * case we force a full page reload immediately: on the next load,
+ * initAnalytics() sees the freshly stored "declined" value and never calls
+ * loadProviders() at all, so nothing loads and nothing keeps tracking.
  */
 export const declineAnalyticsConsent = () => {
   if (!isBrowser) return;
+  const providersWereLoaded = initialized;
   try {
     window.localStorage.setItem(CONSENT_STORAGE_KEY, CONSENT_DECLINED);
   } catch {
     // localStorage unavailable — nothing to persist, but we also never
     // call loadProviders(), so analytics still doesn't load this session.
+  }
+  if (providersWereLoaded) {
+    window.location.reload();
   }
 };
 
@@ -183,6 +216,7 @@ export const __resetAnalyticsForTests = () => {
 /** Fire on every route change (SPA navigations don't trigger a browser page load). */
 export const trackPageView = (path) => {
   if (!isBrowser) return;
+  if (!hasAnalyticsConsent()) return;
   if (window.gtag) {
     window.gtag("event", "page_view", { page_path: path });
   }
@@ -197,6 +231,7 @@ export const trackPageView = (path) => {
  */
 export const trackAddToCart = ({ id, name, price, quantity, currency = "AUD" }) => {
   if (!isBrowser) return;
+  if (!hasAnalyticsConsent()) return;
   const value = Number(price || 0) * Number(quantity || 1);
 
   if (window.gtag) {
@@ -231,6 +266,7 @@ export const trackAddToCart = ({ id, name, price, quantity, currency = "AUD" }) 
  */
 export const trackCheckoutStarted = ({ value, currency = "AUD", numItems }) => {
   if (!isBrowser) return;
+  if (!hasAnalyticsConsent()) return;
 
   if (window.gtag) {
     window.gtag("event", "begin_checkout", { currency, value: Number(value || 0) });
@@ -250,6 +286,7 @@ export const trackCheckoutStarted = ({ value, currency = "AUD", numItems }) => {
  */
 export const trackPurchase = ({ transactionId, value, currency = "AUD" }) => {
   if (!isBrowser) return;
+  if (!hasAnalyticsConsent()) return;
 
   if (window.gtag) {
     window.gtag("event", "purchase", {

--- a/src/lib/analytics.js
+++ b/src/lib/analytics.js
@@ -7,12 +7,16 @@
 //   VITE_META_PIXEL_ID, VITE_CLARITY_PROJECT_ID). If a var is unset, that
 //   provider is skipped entirely — no empty/invalid tags are ever injected.
 // - Scripts are loaded async and appended to <head> at runtime (never
-//   render-blocking), so they cannot slow down or break checkout.
+//   render-blocking), so they never break checkout — though loading them
+//   still consumes bandwidth/CPU, so they are gated on consent (below).
 // - track* helpers are always safe to call from anywhere in the app, even
 //   before init runs or when a provider isn't configured — they just check
 //   for the relevant global (window.gtag / window.fbq) and no-op otherwise.
 // - Disabled on localhost/dev so local testing never pollutes real analytics
 //   data (matches the convention the previous inline GA snippet used).
+// - Gated on cookie consent: none of GA4/Meta Pixel/Clarity load until the
+//   shopper explicitly accepts via the cookie banner (see CookieConsentBanner).
+//   Declining (or not yet deciding) means the scripts are never injected.
 
 const GA_MEASUREMENT_ID = import.meta.env.VITE_GA_MEASUREMENT_ID;
 const META_PIXEL_ID = import.meta.env.VITE_META_PIXEL_ID;
@@ -25,6 +29,23 @@ const isLocalDev = () => {
   const host = window.location.hostname;
   return host === "localhost" || host === "127.0.0.1" || host === "::1";
 };
+
+/** localStorage key holding the shopper's cookie-consent decision. */
+export const CONSENT_STORAGE_KEY = "sm_analytics_consent";
+export const CONSENT_ACCEPTED = "accepted";
+export const CONSENT_DECLINED = "declined";
+
+/** Returns "accepted" | "declined" | null (no decision made yet). */
+export const getStoredConsent = () => {
+  if (!isBrowser) return null;
+  try {
+    return window.localStorage.getItem(CONSENT_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+};
+
+export const hasAnalyticsConsent = () => getStoredConsent() === CONSENT_ACCEPTED;
 
 let initialized = false;
 
@@ -74,7 +95,10 @@ const initMetaPixel = () => {
   window._fbq = window._fbq || window.fbq;
 
   window.fbq("init", META_PIXEL_ID);
-  window.fbq("track", "PageView");
+  // Do NOT fire an initial "PageView" here. App.jsx's route-tracking effect
+  // (trackPageView, below) already fires once on initial mount and once per
+  // subsequent navigation — it is the single source of truth for PageView
+  // events. Firing one here too double-counts every hard-loaded page.
 
   appendScript("https://connect.facebook.net/en_US/fbevents.js");
 };
@@ -91,8 +115,12 @@ const initClarity = () => {
   appendScript(`https://www.clarity.ms/tag/${CLARITY_PROJECT_ID}`);
 };
 
-/** Call once on app startup. Safe to call multiple times (no-ops after the first). */
-export const initAnalytics = () => {
+/**
+ * Actually injects the provider scripts. Guarded so it only ever runs once
+ * per page load no matter how many times it's called (consent grant,
+ * startup check, re-renders, etc).
+ */
+const loadProviders = () => {
   if (!isBrowser || initialized) return;
   initialized = true;
 
@@ -101,6 +129,55 @@ export const initAnalytics = () => {
   initGoogleAnalytics();
   initMetaPixel();
   initClarity();
+};
+
+/**
+ * Call once on app startup. Only loads GA4/Meta Pixel/Clarity if the shopper
+ * already accepted analytics cookies on a previous visit — otherwise this is
+ * a no-op and nothing is injected until `grantAnalyticsConsent()` runs.
+ * Safe to call multiple times (no-ops after the first successful load).
+ */
+export const initAnalytics = () => {
+  if (!isBrowser) return;
+  if (!hasAnalyticsConsent()) return;
+  loadProviders();
+};
+
+/**
+ * Call when the shopper accepts the cookie banner. Persists the decision so
+ * future visits don't re-prompt, and loads the providers for the first time
+ * (no-ops if they're already loaded).
+ */
+export const grantAnalyticsConsent = () => {
+  if (!isBrowser) return;
+  try {
+    window.localStorage.setItem(CONSENT_STORAGE_KEY, CONSENT_ACCEPTED);
+  } catch {
+    // localStorage unavailable (private browsing, etc.) — consent won't
+    // persist across reloads, but scripts still load for this session.
+  }
+  loadProviders();
+};
+
+/**
+ * Call when the shopper declines the cookie banner. Persists the decision so
+ * GA4/Meta Pixel/Clarity are never loaded on this device/browser — this only
+ * flips a flag; it never calls loadProviders(), so no script tag is ever
+ * injected and no provider global (gtag/fbq/clarity) is ever defined.
+ */
+export const declineAnalyticsConsent = () => {
+  if (!isBrowser) return;
+  try {
+    window.localStorage.setItem(CONSENT_STORAGE_KEY, CONSENT_DECLINED);
+  } catch {
+    // localStorage unavailable — nothing to persist, but we also never
+    // call loadProviders(), so analytics still doesn't load this session.
+  }
+};
+
+/** Test-only: allows test suites to reset the module-level init guard. */
+export const __resetAnalyticsForTests = () => {
+  initialized = false;
 };
 
 /** Fire on every route change (SPA navigations don't trigger a browser page load). */

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -16,8 +16,10 @@ import { ProductsContextProvider } from "./context/ProductsContext.jsx";
 import CartInitializer from "./pages/cartInitializer.jsx";
 import { initAnalytics } from "./lib/analytics";
 
-// Fires GA4 / Meta Pixel / Clarity init (each is a no-op if its env var
-// isn't set). Scripts load async and never block this render.
+// Fires GA4 / Meta Pixel / Clarity init, but only if the shopper already
+// accepted analytics cookies on a previous visit (see CookieConsentBanner /
+// src/lib/analytics.js). Each provider is also a no-op if its env var isn't
+// set. Scripts load async and never block this render.
 initAnalytics();
 
 // Create a QueryClient instance

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -14,6 +14,11 @@ import App from "./App.jsx";
 import { AppContextProvider } from "./context/AppContext";
 import { ProductsContextProvider } from "./context/ProductsContext.jsx";
 import CartInitializer from "./pages/cartInitializer.jsx";
+import { initAnalytics } from "./lib/analytics";
+
+// Fires GA4 / Meta Pixel / Clarity init (each is a no-op if its env var
+// isn't set). Scripts load async and never block this render.
+initAnalytics();
 
 // Create a QueryClient instance
 const queryClient = new QueryClient({

--- a/src/redux/middleware/analyticsMiddleware.js
+++ b/src/redux/middleware/analyticsMiddleware.js
@@ -1,0 +1,36 @@
+// src/redux/middleware/analyticsMiddleware.js
+//
+// Every "add to cart" call site in the app (PDP, deal detail page, sticky
+// add-to-cart bar, sample ordering, etc.) dispatches the same
+// `cart/addToCart` redux action. Rather than duplicate a trackAddToCart()
+// call across every one of those components, we hook it once here — this
+// middleware fires for every dispatch of that action, regardless of which
+// component triggered it.
+
+import { trackAddToCart } from "@/lib/analytics";
+
+const norm = (value) => String(value ?? "").trim().toLowerCase();
+
+export const analyticsMiddleware = () => (next) => (action) => {
+  const result = next(action);
+
+  if (action?.type === "cart/addToCart") {
+    try {
+      const payload = action.payload || {};
+      const isDeal = norm(payload.itemType || payload.type) === "deal";
+      const name = payload.name || payload.deal?.name || (isDeal ? "Deal" : "Product");
+
+      trackAddToCart({
+        id: payload.id,
+        name,
+        price: Number(payload.price || 0),
+        quantity: Number(payload.quantity || payload.multiplier || 1),
+        currency: "AUD",
+      });
+    } catch {
+      // Analytics must never break the actual add-to-cart flow.
+    }
+  }
+
+  return result;
+};

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -8,6 +8,7 @@ import filterSlice from "./slices/filterSlice";
 import categoryReducer from "./slices/categorySlice";
 import promotionalReducer from "./slices/promotionalSlice";
 import favouriteReducer from "./slices/favouriteSlice";
+import { analyticsMiddleware } from "./middleware/analyticsMiddleware";
 
 // 1️⃣ Create a root reducer
 const rootReducer = combineReducers({
@@ -64,7 +65,7 @@ export const store = configureStore({
         // redux-persist dispatches some non-serializable actions — ignore those
         ignoredActions: ["persist/PERSIST", "persist/REHYDRATE"],
       },
-    }),
+    }).concat(analyticsMiddleware),
 });
 
 // 5️⃣ Export a persistor


### PR DESCRIPTION
## Summary

Installs three analytics tools on the customer-facing storefront, all driven by env vars with graceful no-op behavior when unset (no hardcoded IDs, no crashes/blank tags if a var is missing):

1. **Google Analytics 4** (gtag.js)
2. **Meta (Facebook) Pixel**
3. **Microsoft Clarity** — added as a third recommendation. It's free (no traffic cap on the free tier), gives session replay + heatmaps, and is genuinely complementary to GA4/Meta: those two tell you *that* a checkout step is leaking users, Clarity lets you actually watch a recording and see *why* (e.g. a confusing field, a broken control). Very low script weight for the signal it adds on a small ecommerce site. Skip it if you'd rather not add another script — it's fully optional and does nothing unless its env var is set.

All logic lives in `src/lib/analytics.js`. Scripts are appended to `<head>` asynchronously at runtime (never inline/blocking), so this can't break the Stripe checkout flow — though loading them still consumes bandwidth/CPU/main-thread time and can affect page responsiveness metrics, which is one reason they're now gated on consent (see below) rather than always-on. No CSP exists in this repo today (checked `vercel.json` and `index.html` — nothing to weaken); if a CSP is added later it will need to allow `googletagmanager.com`, `google-analytics.com`, `connect.facebook.net`/`facebook.com`, and `clarity.ms`.

---

## Update: adversarial review findings, all fixed

An independent review (dual-LLM process — ChatGPT reviewing this Claude-built PR) flagged six issues. Status:

### 1. FIXED (HIGH) — purchase conversions could be lost after a successful order
`trackPurchase()` used to fire only after `await loadUserOrder()` (an unrelated account/order-refresh call) succeeded. If that refresh failed for any reason, the customer had already been charged and the order already created, but no purchase event fired — silently losing revenue attribution.

Fixed in `src/components/checkout/Checkout.jsx`: `trackPurchase()` now fires immediately once the checkout API call itself resolves successfully. `loadUserOrder()` still runs afterward for its own purpose (refreshing the account UI) but is wrapped in try/catch so it can never suppress analytics or block the redirect to the order confirmation page.

### 2. FIXED (MEDIUM) — every initial Meta PageView was counted twice
`initMetaPixel()` fired an initial `PageView` during init, and App.jsx's route-tracking effect also fired one on initial mount — double-counting every hard-loaded page.

Fixed in `src/lib/analytics.js`: removed the init-time `PageView` call. App.jsx's `trackPageView` effect is now the single source of truth for every PageView (initial and subsequent). Also found and **resolved the exact inline PR review comment** flagging this (github.com/super-merch/supermerch-frontend/pull/168#discussion_r3703102831) with a reply and marked the thread resolved.

### 3. FIXED (HIGH, governance/consent gap) — analytics loaded with no working consent gate
GA4, Meta Pixel, and Clarity all loaded immediately with no real consent mechanism. A `CookieModal` component existed but was never mounted, and its Accept/Decline buttons both no-op'd.

Fixed:
- `src/lib/analytics.js` now persists a real consent decision to `localStorage` (`sm_analytics_consent`: `"accepted"` / `"declined"`) via `getStoredConsent()` / `grantAnalyticsConsent()` / `declineAnalyticsConsent()`. **Declining, or not having decided yet, means the three provider `<script>` tags are never injected at all** — not just that events are suppressed.
- New `src/components/Common/CookieConsentBanner.jsx` mounts the (previously dead-code) `CookieModal` in `App.jsx` for real. Prompts once per device when no decision is stored; never blocks browsing, cart, or checkout.
- Added a "Cookie Preferences" link in the footer (`Footer.jsx`) that dispatches an `openCookiePreferences` window event, letting a shopper reopen the banner and change their mind later without re-prompting everyone on every visit.

### 4. FIXED (MEDIUM) — no automated tests for any of the tracking logic
Added 18 new tests across 4 new files (`npm run test`: **1783 tests / 28 files, all passing**, up from 1765/24 before this update):
- `src/__tests__/analytics.test.js` — no scripts inject with all env vars unset even after consent is granted; each provider loads exactly once across repeated grant/init calls (re-render safe); declining (or no stored decision) keeps all three providers from ever loading; a stored prior accept auto-loads on startup; `initMetaPixel` no longer queues its own PageView.
- `src/__tests__/appPageView.test.jsx` — exactly one `trackPageView` on initial mount, exactly one more per subsequent navigation.
- `src/__tests__/checkoutPurchaseTracking.test.jsx` — a successful checkout records the purchase event even when `loadUserOrder()` rejects; a failed checkout never records one.
- `src/__tests__/analyticsMiddleware.test.js` — dispatching the real, shared `cart/addToCart` redux action produces exactly one `trackAddToCart()` call with correct id/name/price/quantity, for both regular products and deal line items.

### 5. FIXED (LOW) — overstated "won't slow checkout" performance claim
Reworded above and in code comments: async loading means it can't *break* checkout, but it isn't free — it still costs bandwidth/CPU/main-thread time, which is part of the reasoning for gating it on consent.

### 6. Noted, no code change needed — Vercel env var sequencing
Flagging prominently again since not yet acted on: **`VITE_GA_MEASUREMENT_ID`, `VITE_META_PIXEL_ID`, and `VITE_CLARITY_PROJECT_ID` must be set in Vercel (Production, and optionally Preview) BEFORE the next production build.** Vite bakes env vars in at build time — setting them after a build won't retroactively enable tracking; it requires a rebuild. Until they're set, GA4/Meta/Clarity simply won't load, which is expected/correct behavior for a not-yet-configured feature, not a bug.

---

## Open questions still needing the business owner's input (unchanged from original PR — re-flagging, not yet answered)

1. **Is the previously-hardcoded GA4 ID `G-RYN804XC9M` (removed from `index.html` by the original PR) a real, already-active GA4 property for this business?** It predates any deliberate analytics work and its provenance couldn't be confirmed from the frontend code alone. If it's real and already collecting data, it should become the value of `VITE_GA_MEASUREMENT_ID` in Vercel to preserve historical continuity instead of starting a fresh property. **This still needs a human to check GA4 directly (sign in, look for a property with that measurement ID).**
2. **Does the live privacy policy text disclose use of GA4, Meta Pixel, and Microsoft Clarity / cookies generally?** The `/privacy` page content is fetched dynamically from the backend CMS, not stored in this repo, so this can't be verified from the frontend codebase. Given the consent banner is now live and gating real tracking, **the business owner should check the actual policy text via the CMS/admin and add a line about these three providers if it isn't already there.**

---

## Update: second adversarial review findings, all fixed

A second independent review (same dual-LLM process — ChatGPT re-reviewing after round 1 above landed) confirmed all six round-1 fixes were correct, then found 3 more issues specifically in the **consent lifecycle** — i.e. what happens when a shopper who already accepted later changes their mind.

### 1. FIXED (HIGH) — withdrawing consent didn't actually stop active tracking
Repro: accept → GA4/Meta/Clarity load → reopen "Cookie Preferences" from the footer → click Decline. Previously this only flipped the `localStorage` value to `"declined"` — the already-loaded scripts, `window.gtag`/`window.fbq`/`window.clarity`, and any listeners kept running for the rest of that page session, and `trackPageView`/`trackAddToCart`/`trackCheckoutStarted`/`trackPurchase` kept firing because they only checked whether the provider globals happened to exist, never the actual current consent state.

Fixed two ways in `src/lib/analytics.js`:
- `declineAnalyticsConsent()` now forces a full page reload immediately after persisting the decline, but only when providers had already been loaded this session. On reload, `initAnalytics()` sees the stored `"declined"` value and never calls `loadProviders()`, so nothing loads at all — full stop, not just "stop from now on in this tab."
- As defense-in-depth, every `track*` helper (`trackPageView`, `trackAddToCart`, `trackCheckoutStarted`, `trackPurchase`) now checks `hasAnalyticsConsent()` up front and no-ops immediately if consent isn't currently `"accepted"` — independent of the reload, and independent of whether `window.gtag`/`window.fbq` still exist.

### 2. FIXED (MEDIUM) — the entry page's own page view was lost on first-time accept
On initial render, App.jsx's route-tracking effect calls `trackPageView()` immediately — but before any consent decision exists, this is now an explicit no-op (per fix 1 above). When the visitor accepts moments later, providers load, but nothing ever emitted a page view for the page they were already on: GA4/Meta only started seeing pageviews from the *next* navigation onward, silently losing the entry page.

Fixed: `grantAnalyticsConsent()` now emits exactly one `page_view`/`PageView` for the current page, but only on the transition from not-loaded to loaded — a returning visitor whose providers already loaded normally at startup (from a previously-stored "accepted" decision) does **not** get a duplicate, since they already get their pageview from App.jsx's normal mount effect.

### 3. FIXED (MEDIUM) — cookie banner wording contradicted the implementation
The banner said "By continuing to use our site, you consent to our use of cookies" — implying passive/implied consent just from browsing, which is exactly what the actual code (explicit opt-in via `grantAnalyticsConsent()`) does not do.

Fixed in `src/components/Home/Modals/CookieModal.jsx`: rewritten to name the three providers (Google Analytics, Meta Pixel, Microsoft Clarity), state plainly that they only activate after clicking "Accept All", and link to the Privacy Policy — kept concise, this is a banner, not a legal document.

### New regression tests
Added 8 tests to `src/__tests__/analytics.test.js` (2 rewritten + 6 new) proving: first accept fires exactly one page_view/PageView for the current page; a returning "accepted" visitor gets exactly one page view on startup (not two); re-affirming Accept when providers already loaded doesn't add an extra one; every `track*` helper is an immediate no-op after Decline without needing a reload; and Decline actually triggers a page reload (and does *not* when providers were never loaded). Full suite: **28 test files / 1789 tests, all passing** (up from 1783 before this update).

## Test plan

- [x] `npm run lint` — zero new lint errors/warnings in any file touched by this update (pre-existing unrelated lint debt unchanged)
- [x] `npm run test` — all 28 test files / 1789 tests pass locally
- [x] Pushed to this branch and verified via `gh pr checks 168` — CodeRabbit, Vercel, and Vercel Preview Comments all report `pass`
- [ ] Manual QA once real IDs are set in a Preview deployment: confirm GA4 DebugView / Meta Pixel Helper / Clarity dashboard all receive events, confirm the cookie banner shows once and Accept/Decline actually gate script loading, confirm declining after accepting reloads the page and stops all three providers, and confirm checkout is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

