### PR TITLE
Fix SEO crawlability quick wins: body content, Organization schema, robots mismatch, route splitting

### DIFF
--- a/api/product-page.js
+++ b/api/product-page.js
@@ -70,16 +70,18 @@ const productAttributes = (details) => {
   // not from independent fallback chains -- otherwise promodata_product_type
   // could supply a name while product_type supplies an unrelated ID, and the
   // visible breadcrumb/JSON-LD would describe one category while linking to
-  // another. Pick whichever source actually has a type_id first, since the
-  // client's /shop?category=X route (see Cards.jsx) treats X as a
-  // productTypeId sent straight to the backend as product_type_ids -- a
-  // label with no matching ID from the same object is not a safe link
-  // target.
-  const productType = categorisation?.promodata_product_type?.type_id
-    ? categorisation.promodata_product_type
-    : categorisation?.product_type?.type_id
-      ? categorisation.product_type
-      : null;
+  // another. Only an object carrying BOTH a usable type_id AND type_name
+  // qualifies -- selecting on type_id alone would let a same-object
+  // type_name gap silently fall back to the unrelated supplier_category
+  // label while still keeping that object's ID, recreating the exact
+  // mismatch this is meant to prevent. The client's /shop?category=X route
+  // (see Cards.jsx) treats the value as a productTypeId sent straight to
+  // the backend as product_type_ids -- a label with no matching ID from
+  // the same object is not a safe link target.
+  const productType = [
+    categorisation?.promodata_product_type,
+    categorisation?.product_type,
+  ].find((item) => cleanText(item?.type_id) && cleanText(item?.type_name));
   const category = cleanText(
     productType?.type_name || categorisation?.supplier_category,
   );

--- a/api/product-page.js
+++ b/api/product-page.js
@@ -66,21 +66,24 @@ const detailValue = (details, names) => {
 
 const productAttributes = (details) => {
   const categorisation = details.categorisation || {};
+  // category (label) and categoryId must come from the SAME source object,
+  // not from independent fallback chains -- otherwise promodata_product_type
+  // could supply a name while product_type supplies an unrelated ID, and the
+  // visible breadcrumb/JSON-LD would describe one category while linking to
+  // another. Pick whichever source actually has a type_id first, since the
+  // client's /shop?category=X route (see Cards.jsx) treats X as a
+  // productTypeId sent straight to the backend as product_type_ids -- a
+  // label with no matching ID from the same object is not a safe link
+  // target.
+  const productType = categorisation?.promodata_product_type?.type_id
+    ? categorisation.promodata_product_type
+    : categorisation?.product_type?.type_id
+      ? categorisation.product_type
+      : null;
   const category = cleanText(
-    categorisation?.promodata_product_type?.type_name ||
-      categorisation?.product_type?.type_name ||
-      categorisation?.supplier_category,
+    productType?.type_name || categorisation?.supplier_category,
   );
-  // The client's /shop?category=X route (see Cards.jsx) treats X as a
-  // productTypeId sent straight to the backend as product_type_ids -- it is
-  // never the human-readable type_name. Only promodata_product_type/
-  // product_type carry a real type_id; supplier_category has no ID
-  // equivalent, so a category resolved only from that fallback has no safe
-  // link target.
-  const categoryId = cleanText(
-    categorisation?.promodata_product_type?.type_id ||
-      categorisation?.product_type?.type_id,
-  );
+  const categoryId = cleanText(productType?.type_id);
   const material =
     detailValue(details.details, ["Material", "Materials"]) ||
     cleanText(

--- a/api/product-page.js
+++ b/api/product-page.js
@@ -132,6 +132,40 @@ const injectHead = (html, tags) => {
   return output.replace("</head>", `${tags}\n</head>`);
 };
 
+// Renders real, crawlable breadcrumb links as plain <a> tags. The final
+// (current-page) crumb has no href, matching how visible breadcrumbs render
+// elsewhere on the site.
+const renderBreadcrumbLinks = (items) =>
+  items
+    .map((item) =>
+      item.href
+        ? `<a href="${escapeHtml(item.href)}">${escapeHtml(item.label)}</a>`
+        : `<span>${escapeHtml(item.label)}</span>`,
+    )
+    .join(' <span aria-hidden="true">/</span> ');
+
+/**
+ * Injects a small, real, crawlable content block directly into the SPA's
+ * mount point (#root) — an H1, a description paragraph, and breadcrumb
+ * links — instead of only <head> meta tags. main.jsx mounts React with
+ * createRoot() (not hydrateRoot()), so React fully replaces #root's
+ * contents on mount rather than diffing against them: there is no
+ * hydration to mismatch, and once JS runs this markup is simply discarded
+ * in favour of the real client-rendered page.
+ */
+const injectBody = (html, bodyHtml) =>
+  html.replace(
+    /<div id=["']root["']><\/div>/,
+    `<div id="root">${bodyHtml}</div>`,
+  );
+
+const renderProductBody = ({ name, description, breadcrumbItems }) => `
+<div data-ssr-content="product">
+<nav aria-label="Breadcrumb">${renderBreadcrumbLinks(breadcrumbItems)}</nav>
+<h1>${escapeHtml(name)}</h1>
+<p>${escapeHtml(description)}</p>
+</div>`;
+
 const getIdentifier = (query) => {
   if (query.id !== undefined && String(query.id).trim()) {
     return String(query.id).trim();
@@ -243,9 +277,10 @@ export default async function handler(req, res) {
   const name =
     cleanText(details.name || overview.name || overview.originalName) ||
     "Promotional Product";
-  const description = cleanText(
+  const rawDescription = cleanText(
     details.description || overview.description || details.short_description,
-  ).slice(0, 160);
+  );
+  const description = rawDescription.slice(0, 160);
   const productId =
     product?.meta?.id ?? overview.sku_number ?? details.code ?? identifier;
   const sku = overview.sku_number || details.code || "";
@@ -333,15 +368,41 @@ export default async function handler(req, res) {
     };
   }
 
+  // Real breadcrumb trail — reused for both the visible <a> links injected
+  // into #root and the BreadcrumbList JSON-LD below, so the two never
+  // contradict each other. Category links point at /shop?category=X, the
+  // same route the SEO layer for /shop already treats as that category's
+  // canonical page (see api/seo-page.js).
+  const breadcrumbItems = [
+    { label: "Home", href: "/" },
+    { label: "Shop", href: "/shop" },
+    ...(attributes.category
+      ? [
+          {
+            label: attributes.category,
+            href: `/shop?category=${encodeURIComponent(attributes.category)}`,
+          },
+        ]
+      : []),
+    { label: name, href: null },
+  ];
+
   const breadcrumbSchema = {
     "@context": "https://schema.org",
     "@type": "BreadcrumbList",
-    itemListElement: [
-      { "@type": "ListItem", position: 1, name: "Home", item: `${SITE_URL}/` },
-      { "@type": "ListItem", position: 2, name: "Shop", item: `${SITE_URL}/shop` },
-      { "@type": "ListItem", position: 3, name, item: canonical },
-    ],
+    itemListElement: breadcrumbItems.map((item, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: item.label,
+      item: item.href ? `${SITE_URL}${item.href}` : canonical,
+    })),
   };
+
+  const bodyContent = renderProductBody({
+    name,
+    description: rawDescription.slice(0, 500) || metaDescription,
+    breadcrumbItems,
+  });
 
   const tags = `
 <title>${escapeHtml(title)}</title>
@@ -366,5 +427,5 @@ ${keywords ? `<meta name="keywords" content="${escapeHtml(keywords)}">` : ""}
 
   res.setHeader("Content-Type", "text/html; charset=utf-8");
   res.setHeader("Cache-Control", "public, s-maxage=3600, stale-while-revalidate=86400");
-  res.status(200).send(injectHead(shell, tags));
+  res.status(200).send(injectBody(injectHead(shell, tags), bodyContent));
 }

--- a/api/product-page.js
+++ b/api/product-page.js
@@ -71,6 +71,16 @@ const productAttributes = (details) => {
       categorisation?.product_type?.type_name ||
       categorisation?.supplier_category,
   );
+  // The client's /shop?category=X route (see Cards.jsx) treats X as a
+  // productTypeId sent straight to the backend as product_type_ids -- it is
+  // never the human-readable type_name. Only promodata_product_type/
+  // product_type carry a real type_id; supplier_category has no ID
+  // equivalent, so a category resolved only from that fallback has no safe
+  // link target.
+  const categoryId = cleanText(
+    categorisation?.promodata_product_type?.type_id ||
+      categorisation?.product_type?.type_id,
+  );
   const material =
     detailValue(details.details, ["Material", "Materials"]) ||
     cleanText(
@@ -87,6 +97,7 @@ const productAttributes = (details) => {
   );
   return {
     category,
+    categoryId,
     material,
     color,
     capacity: detailValue(details.details, ["Capacity", "Volume"]),
@@ -370,17 +381,20 @@ export default async function handler(req, res) {
 
   // Real breadcrumb trail — reused for both the visible <a> links injected
   // into #root and the BreadcrumbList JSON-LD below, so the two never
-  // contradict each other. Category links point at /shop?category=X, the
-  // same route the SEO layer for /shop already treats as that category's
-  // canonical page (see api/seo-page.js).
+  // contradict each other. Category links point at /shop?category=<id>:
+  // Cards.jsx treats that value as a productTypeId and sends it to the
+  // backend as product_type_ids, so the URL must carry the real type_id,
+  // not the human-readable category label -- the label is display text
+  // only. If no type_id was resolved, the category has no safe link
+  // target, so the crumb is omitted rather than publishing a broken URL.
   const breadcrumbItems = [
     { label: "Home", href: "/" },
     { label: "Shop", href: "/shop" },
-    ...(attributes.category
+    ...(attributes.category && attributes.categoryId
       ? [
           {
             label: attributes.category,
-            href: `/shop?category=${encodeURIComponent(attributes.category)}`,
+            href: `/shop?category=${encodeURIComponent(attributes.categoryId)}`,
           },
         ]
       : []),

--- a/api/seo-page.js
+++ b/api/seo-page.js
@@ -1,23 +1,9 @@
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-
-// The full, authoritative leaf+parent category ID inventory (297 leaves +
-// 27 parents as of its last fetch) -- independent of whether an admin has
-// configured an SEO override for any given ID. Used to decide whether a
+// Shared with the client (src/utils/shopSeo.js, RouteSeo.jsx) so both sides
+// agree on exactly the same category IDs -- used to decide whether a
 // /shop?category=X value is a real category (self-canonical, indexable)
 // or arbitrary/invalid input (canonicalize to plain /shop, noindex) --
 // admin-override presence must never be used as that validity signal.
-const categoryIdsPath = fileURLToPath(
-  new URL(
-    "../scripts/category-finder/authoritative-category-ids.json",
-    import.meta.url,
-  ),
-);
-const { leaves: authoritativeLeaves, parents: authoritativeParents } =
-  JSON.parse(readFileSync(categoryIdsPath, "utf8"));
-const VALID_CATEGORY_IDS = new Set(
-  [...authoritativeLeaves, ...authoritativeParents].map((item) => item.id),
-);
+import { isValidCategoryId } from "../src/utils/categoryValidity.js";
 
 const SITE_URL = "https://www.supermerch.com.au";
 const BACKEND_URL =
@@ -313,7 +299,7 @@ export default async function handler(req, res) {
     path === "/shop" ? String(req.query.category || "").trim() : "";
   // Whether `category` is a real leaf/parent product-type ID, not whether
   // an admin has configured an SEO override for it -- those are unrelated.
-  const isValidCategory = category ? VALID_CATEGORY_IDS.has(category) : false;
+  const isValidCategory = isValidCategoryId(category);
 
   let shell;
   try {

--- a/api/seo-page.js
+++ b/api/seo-page.js
@@ -350,7 +350,14 @@ export default async function handler(req, res) {
         : "index, follow";
   }
 
-  const override = await fetchSeoOverride(page.entityType, page.entityId);
+  // An invalid /shop?category=X value must never be indexable, even if a
+  // stale or mistaken admin SEO override exists for that exact entityId --
+  // otherwise its canonicalUrl could win below and reintroduce the SSR/CSR
+  // disagreement the validity check exists to prevent.
+  const override =
+    path === "/shop" && category && !isValidCategory
+      ? null
+      : await fetchSeoOverride(page.entityType, page.entityId);
   const title = cleanText(override?.metaTitle) || page.title;
   const description =
     cleanText(override?.metaDescription).slice(0, 160) || page.description;

--- a/api/seo-page.js
+++ b/api/seo-page.js
@@ -205,6 +205,86 @@ const injectHead = (html, tags) => {
   return output.replace("</head>", `${tags}\n</head>`);
 };
 
+// Renders real, crawlable breadcrumb links as plain <a> tags. The final
+// (current-page) crumb has no href, matching how visible breadcrumbs render
+// elsewhere on the site.
+const renderBreadcrumbLinks = (items) =>
+  items
+    .map((item) =>
+      item.href
+        ? `<a href="${escapeHtml(item.href)}">${escapeHtml(item.label)}</a>`
+        : `<span>${escapeHtml(item.label)}</span>`,
+    )
+    .join(' <span aria-hidden="true">/</span> ');
+
+/**
+ * Injects a small, real, crawlable content block directly into the SPA's
+ * mount point (#root) — an H1, a description paragraph, and breadcrumb
+ * links — instead of only <head> meta tags. main.jsx mounts React with
+ * createRoot() (not hydrateRoot()), so React fully replaces #root's
+ * contents on mount rather than diffing against them: there is no
+ * hydration to mismatch, and once JS runs this markup is simply discarded
+ * in favour of the real client-rendered page.
+ */
+const injectBody = (html, bodyHtml) =>
+  html.replace(
+    /<div id=["']root["']><\/div>/,
+    `<div id="root">${bodyHtml}</div>`,
+  );
+
+const SITE_SUFFIX = / \| Super Merch Australia$/i;
+
+// Builds the same breadcrumb trail used for both the visible <a> links and
+// (where present) any future structured data — a category page sits under
+// Shop, a blog post under Blog, a deal under Deals; everything else sits
+// directly under Home. The homepage itself gets no breadcrumb.
+const buildBreadcrumbItems = (path, entityType, displayName) => {
+  if (path === "/") return [];
+  const items = [{ label: "Home", href: "/" }];
+  if (entityType === "category" && displayName !== "Shop") {
+    items.push({ label: "Shop", href: "/shop" });
+  } else if (entityType === "blog" && displayName !== "Blog") {
+    items.push({ label: "Blog", href: "/all-blogs" });
+  } else if (entityType === "deal" && displayName !== "Deals") {
+    items.push({ label: "Deals", href: "/deals" });
+  }
+  items.push({ label: displayName, href: null });
+  return items;
+};
+
+const renderPageBody = ({ displayName, description, breadcrumbItems }) => `
+<div data-ssr-content="page">
+${breadcrumbItems.length ? `<nav aria-label="Breadcrumb">${renderBreadcrumbLinks(breadcrumbItems)}</nav>\n` : ""}<h1>${escapeHtml(displayName)}</h1>
+<p>${escapeHtml(description)}</p>
+</div>`;
+
+// Query params that don't create a distinct, thin/duplicate variant of a
+// /shop page: `category` selects the canonical category view itself, and
+// the rest are already stripped when building the canonical URL below.
+const BENIGN_SHOP_PARAMS = new Set([
+  "category",
+  "page",
+  "sort",
+  "view",
+  "gclid",
+  "fbclid",
+]);
+
+/**
+ * True when /shop has facet/filter params beyond the ones above (e.g.
+ * color, size, price range). Those combinations create combinatorial,
+ * largely duplicate content and should be kept out of the index while the
+ * canonical /shop and /shop?category=X views stay indexable. Must match
+ * hasShopFilterParams() in src/utils/shopSeo.js, which drives the same
+ * decision client-side.
+ */
+const hasShopFilterParams = (query) =>
+  Object.keys(query).some((key) => {
+    if (key === "path") return false;
+    const normalized = key.toLowerCase();
+    return !BENIGN_SHOP_PARAMS.has(normalized) && !normalized.startsWith("utm_");
+  });
+
 export default async function handler(req, res) {
   const rawPath = String(req.query.path || "/");
   const path = rawPath.startsWith("/") ? rawPath : `/${rawPath}`;
@@ -243,6 +323,16 @@ export default async function handler(req, res) {
     res.setHeader("Content-Type", "text/html; charset=utf-8");
     res.status(404).send(injectHead(shell, tags));
     return;
+  }
+
+  // Faceted/filtered /shop URLs (color, size, price, etc.) are thin,
+  // largely duplicate variants of the canonical category view — keep them
+  // out of the index while /shop and /shop?category=X stay indexable. Must
+  // match the client-side robots decision in src/components/Common/RouteSeo.jsx.
+  if (path === "/shop") {
+    page.robots = hasShopFilterParams(req.query)
+      ? "noindex, follow"
+      : "index, follow";
   }
 
   const override = await fetchSeoOverride(page.entityType, page.entityId);
@@ -360,7 +450,15 @@ export default async function handler(req, res) {
 <meta name="twitter:url" content="${escapeHtml(canonical)}">
 ${jsonLdTags}`;
 
+  const displayName = title.replace(SITE_SUFFIX, "").trim() || title;
+  const breadcrumbItems = buildBreadcrumbItems(path, page.entityType, displayName);
+  const bodyContent = renderPageBody({
+    displayName,
+    description,
+    breadcrumbItems,
+  });
+
   res.setHeader("Content-Type", "text/html; charset=utf-8");
   res.setHeader("Cache-Control", "public, s-maxage=3600, stale-while-revalidate=86400");
-  res.status(200).send(injectHead(shell, tags));
+  res.status(200).send(injectBody(injectHead(shell, tags), bodyContent));
 }

--- a/api/seo-page.js
+++ b/api/seo-page.js
@@ -343,10 +343,17 @@ export default async function handler(req, res) {
   const socialDescription =
     cleanText(override?.ogDescription).slice(0, 200) || description;
   const socialImage = cleanText(override?.ogImage) || page.image;
-  const canonicalPath =
-    path === "/shop" && category && !override
-      ? "/shop"
-      : page.canonicalPath || path;
+  // A /shop?category=X view is self-canonical whenever it's indexable (see
+  // the robots decision above, which already excludes faceted/filtered
+  // variants) -- whether an admin has configured a custom SEO override for
+  // that specific category is unrelated to whether the URL itself is the
+  // canonical page. Collapsing to plain "/shop" here used to happen for
+  // every category with no override (i.e. nearly all ~297 of them), which
+  // told Google the real/preferred page was the generic shop listing even
+  // while the robots tag said "index, follow" on this URL -- a direct
+  // contradiction that actively worked against indexing the category pages
+  // this endpoint exists to make crawlable.
+  const canonicalPath = page.canonicalPath || path;
   const fallbackCanonical = `${SITE_URL}${
     canonicalPath === "/"
       ? "/"

--- a/api/seo-page.js
+++ b/api/seo-page.js
@@ -1,3 +1,24 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+// The full, authoritative leaf+parent category ID inventory (297 leaves +
+// 27 parents as of its last fetch) -- independent of whether an admin has
+// configured an SEO override for any given ID. Used to decide whether a
+// /shop?category=X value is a real category (self-canonical, indexable)
+// or arbitrary/invalid input (canonicalize to plain /shop, noindex) --
+// admin-override presence must never be used as that validity signal.
+const categoryIdsPath = fileURLToPath(
+  new URL(
+    "../scripts/category-finder/authoritative-category-ids.json",
+    import.meta.url,
+  ),
+);
+const { leaves: authoritativeLeaves, parents: authoritativeParents } =
+  JSON.parse(readFileSync(categoryIdsPath, "utf8"));
+const VALID_CATEGORY_IDS = new Set(
+  [...authoritativeLeaves, ...authoritativeParents].map((item) => item.id),
+);
+
 const SITE_URL = "https://www.supermerch.com.au";
 const BACKEND_URL =
   process.env.BACKEND_URL ||
@@ -290,6 +311,9 @@ export default async function handler(req, res) {
   const path = rawPath.startsWith("/") ? rawPath : `/${rawPath}`;
   const category =
     path === "/shop" ? String(req.query.category || "").trim() : "";
+  // Whether `category` is a real leaf/parent product-type ID, not whether
+  // an admin has configured an SEO override for it -- those are unrelated.
+  const isValidCategory = category ? VALID_CATEGORY_IDS.has(category) : false;
 
   let shell;
   try {
@@ -329,10 +353,15 @@ export default async function handler(req, res) {
   // largely duplicate variants of the canonical category view — keep them
   // out of the index while /shop and /shop?category=X stay indexable. Must
   // match the client-side robots decision in src/components/Common/RouteSeo.jsx.
+  // A category value that isn't a real leaf/parent ID (typos, arbitrary
+  // input) must never become indexable -- that would let unlimited junk
+  // category URLs consume crawl budget and appear as thin/duplicate pages,
+  // which is the same problem this PR exists to fix, not solve.
   if (path === "/shop") {
-    page.robots = hasShopFilterParams(req.query)
-      ? "noindex, follow"
-      : "index, follow";
+    page.robots =
+      hasShopFilterParams(req.query) || (category && !isValidCategory)
+        ? "noindex, follow"
+        : "index, follow";
   }
 
   const override = await fetchSeoOverride(page.entityType, page.entityId);
@@ -343,17 +372,22 @@ export default async function handler(req, res) {
   const socialDescription =
     cleanText(override?.ogDescription).slice(0, 200) || description;
   const socialImage = cleanText(override?.ogImage) || page.image;
-  // A /shop?category=X view is self-canonical whenever it's indexable (see
-  // the robots decision above, which already excludes faceted/filtered
-  // variants) -- whether an admin has configured a custom SEO override for
-  // that specific category is unrelated to whether the URL itself is the
+  // A /shop?category=X view is self-canonical whenever it's a real,
+  // indexable category (see the robots decision above, which already
+  // excludes both faceted/filtered variants and invalid category values)
+  // -- whether an admin has configured a custom SEO override for that
+  // specific category is unrelated to whether the URL itself is the
   // canonical page. Collapsing to plain "/shop" here used to happen for
-  // every category with no override (i.e. nearly all ~297 of them), which
-  // told Google the real/preferred page was the generic shop listing even
-  // while the robots tag said "index, follow" on this URL -- a direct
+  // every valid category with no override (i.e. nearly all ~297 of them),
+  // which told Google the real/preferred page was the generic shop listing
+  // even while the robots tag said "index, follow" on this URL -- a direct
   // contradiction that actively worked against indexing the category pages
-  // this endpoint exists to make crawlable.
-  const canonicalPath = page.canonicalPath || path;
+  // this endpoint exists to make crawlable. An invalid category still
+  // canonicalizes to plain "/shop", since it isn't a real page of its own.
+  const canonicalPath =
+    path === "/shop" && category && !isValidCategory
+      ? "/shop"
+      : page.canonicalPath || path;
   const fallbackCanonical = `${SITE_URL}${
     canonicalPath === "/"
       ? "/"

--- a/index.html
+++ b/index.html
@@ -63,6 +63,23 @@
   <!-- Canonical URL -->
   <link rel="canonical" href="https://www.supermerch.com.au/" />
 
+  <!-- Organization structured data — static so it's present in the raw HTML
+       with no JS required. Fixed, non-dynamic content; kept in sync with the
+       former ORGANIZATION_SCHEMA constant in RouteSeo.jsx. -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "@id": "https://www.supermerch.com.au/#organization",
+    "name": "Super Merch",
+    "url": "https://www.supermerch.com.au/",
+    "logo": "https://www.supermerch.com.au/logo-teal.png",
+    "email": "Info@supermerch.com.au",
+    "telephone": "+61466468528",
+    "areaServed": "AU"
+  }
+  </script>
+
   <!-- Preconnect for Performance -->
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,8 +2,6 @@ import { lazy, Suspense, useContext } from "react";
 import Navbar from "./components/Home/Navbar";
 import { Routes, Route } from "react-router-dom";
 import RouteTransition from "./components/Common/RouteTransition";
-import Home from "./pages/Home/Home";
-import ProductPageResolver from "./pages/ProductPageResolver";
 import Footer from "./components/Home/Footer";
 import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
@@ -16,6 +14,16 @@ import RouteSeo from "./components/Common/RouteSeo";
 import CookieConsentBanner from "./components/Common/CookieConsentBanner";
 import { trackPageView } from "./lib/analytics";
 
+// Home and the product detail page are the highest-traffic routes, but they
+// are also (via their shared sub-components) the biggest pullers of heavy
+// third-party libraries (swiper/slick carousels, lightgallery, etc.) into the
+// bundle. Because they were previously imported eagerly, every one of those
+// dependencies ended up in the main entry chunk and was downloaded on every
+// route — checkout, account, about, everything. Both already render inside
+// the <Suspense> boundary below, so lazy-loading them is a drop-in change
+// with no synchronous-availability requirement to preserve.
+const Home = lazy(() => import("./pages/Home/Home"));
+const ProductPageResolver = lazy(() => import("./pages/ProductPageResolver"));
 const CategoryPage = lazy(() => import("./pages/CategoryPage"));
 const ShopPage = lazy(() => import("./pages/ShopPage"));
 const Login = lazy(() => import("./pages/Login"));

--- a/src/__tests__/appPageView.test.jsx
+++ b/src/__tests__/appPageView.test.jsx
@@ -71,21 +71,25 @@ const renderApp = (initialEntries) =>
   );
 
 describe("App PageView tracking", () => {
-  it("fires exactly one trackPageView on initial mount", () => {
+  // Home and ProductPageResolver are lazy-loaded (see src/App.jsx) behind a
+  // <Suspense> boundary, so their mocked modules resolve asynchronously —
+  // use findByText (which awaits) rather than getByText (which is sync-only).
+  it("fires exactly one trackPageView on initial mount", async () => {
     renderApp(["/"]);
 
-    expect(screen.getByText("HomePage")).toBeInTheDocument();
+    expect(await screen.findByText("HomePage")).toBeInTheDocument();
     expect(trackPageViewMock).toHaveBeenCalledTimes(1);
     expect(trackPageViewMock).toHaveBeenCalledWith("/");
   });
 
-  it("fires exactly one additional trackPageView per subsequent navigation, no duplicates", () => {
+  it("fires exactly one additional trackPageView per subsequent navigation, no duplicates", async () => {
     renderApp(["/"]);
+    expect(await screen.findByText("HomePage")).toBeInTheDocument();
     expect(trackPageViewMock).toHaveBeenCalledTimes(1);
 
     fireEvent.click(screen.getByText("go-to-/product/1"));
 
-    expect(screen.getByText("ProductPage")).toBeInTheDocument();
+    expect(await screen.findByText("ProductPage")).toBeInTheDocument();
     expect(trackPageViewMock).toHaveBeenCalledTimes(2);
     expect(trackPageViewMock).toHaveBeenNthCalledWith(2, "/product/1");
   });

--- a/src/__tests__/dynamicSeo.test.js
+++ b/src/__tests__/dynamicSeo.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { toCanonicalUrl } from "../utils/canonicalUrl";
-import { getShopSeoContext } from "../utils/shopSeo";
+import { getShopSeoContext, hasShopFilterParams } from "../utils/shopSeo";
 
 describe("dynamic category SEO", () => {
   it("uses the selected category as the SEO entity", () => {
@@ -23,6 +23,42 @@ describe("dynamic category SEO", () => {
         "https://supermerch.com.au/shop?category=wooden-pens&page=2&sort=price&utm_source=test&gclid=1#products",
       ),
     ).toBe("https://www.supermerch.com.au/shop?category=wooden-pens");
+  });
+});
+
+describe("hasShopFilterParams", () => {
+  it("is false with no query params", () => {
+    expect(hasShopFilterParams("")).toBe(false);
+  });
+
+  it("is false for the canonical category view", () => {
+    expect(hasShopFilterParams("?category=wooden-pens")).toBe(false);
+  });
+
+  it("is false for benign params: page, sort, view, utm_*, gclid, fbclid", () => {
+    expect(
+      hasShopFilterParams(
+        "?category=wooden-pens&page=2&sort=price&view=grid&utm_source=newsletter&utm_campaign=x&gclid=abc&fbclid=xyz",
+      ),
+    ).toBe(false);
+  });
+
+  it("is true for a color facet param", () => {
+    expect(hasShopFilterParams("?color=blue")).toBe(true);
+  });
+
+  it("is true for a size facet param", () => {
+    expect(hasShopFilterParams("?size=large")).toBe(true);
+  });
+
+  it("is true for a price-range facet param even alongside a category", () => {
+    expect(hasShopFilterParams("?category=wooden-pens&priceMin=10&priceMax=50")).toBe(
+      true,
+    );
+  });
+
+  it("is case-insensitive when matching benign param names", () => {
+    expect(hasShopFilterParams("?Category=wooden-pens&Page=2")).toBe(false);
   });
 });
 

--- a/src/__tests__/dynamicSeo.test.js
+++ b/src/__tests__/dynamicSeo.test.js
@@ -4,9 +4,12 @@ import { getShopSeoContext, hasShopFilterParams } from "../utils/shopSeo";
 
 describe("dynamic category SEO", () => {
   it("uses the selected category as the SEO entity", () => {
-    expect(getShopSeoContext("?category=wooden-pens")).toEqual({
-      entityId: "wooden-pens",
-      canonicalPath: "/shop?category=wooden-pens",
+    // PE-02 is a real leaf category ID (Drink Bottles) in
+    // authoritative-category-ids.json, so this also covers the valid case.
+    expect(getShopSeoContext("?category=PE-02")).toEqual({
+      entityId: "PE-02",
+      canonicalPath: "/shop?category=PE-02",
+      isValidCategory: true,
     });
   });
 
@@ -14,6 +17,15 @@ describe("dynamic category SEO", () => {
     expect(getShopSeoContext("")).toEqual({
       entityId: "shop",
       canonicalPath: "/shop",
+      isValidCategory: true,
+    });
+  });
+
+  it("flags a category value with no matching leaf/parent ID as invalid", () => {
+    expect(getShopSeoContext("?category=wooden-pens")).toEqual({
+      entityId: "wooden-pens",
+      canonicalPath: "/shop?category=wooden-pens",
+      isValidCategory: false,
     });
   });
 

--- a/src/__tests__/productPageHandler.test.js
+++ b/src/__tests__/productPageHandler.test.js
@@ -1,0 +1,206 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import handler from "../../api/product-page";
+
+const response = (body, status = 200) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  json: async () => body,
+  text: async () => String(body),
+});
+
+const createResponse = () => {
+  const result = { headers: {}, statusCode: null, body: "" };
+  return {
+    result,
+    setHeader: (key, value) => {
+      result.headers[key] = value;
+    },
+    status: (statusCode) => {
+      result.statusCode = statusCode;
+      return {
+        send: (body) => {
+          result.body = body;
+        },
+      };
+    },
+  };
+};
+
+// Real app shell shape: the SPA's mount point. api/product-page.js's
+// injectBody() only replaces content inside <div id="root"></div> — a
+// fixture without it would let body injection silently no-op while every
+// <head> tag assertion still passes.
+const SHELL_WITH_ROOT =
+  '<html><head><title>Fallback</title></head><body><div id="root"></div></body></html>';
+
+const SHELL_WITHOUT_ROOT =
+  "<html><head><title>Fallback</title></head><body></body></html>";
+
+const baseProduct = {
+  meta: { id: 42 },
+  pricingSummary: { finalMinPrice: 6.25 },
+  overview: {
+    hero_image: "https://images.example.test/bottle.jpg",
+    sku_number: "BOT-42",
+    slug: "ocean-bottle",
+  },
+  product: {
+    name: "Ocean Bottle",
+    slug: "ocean-bottle",
+    description: "<p>Reusable &amp; insulated bottle for the outdoors.</p>",
+    categorisation: {
+      promodata_product_type: { type_name: "Drink Bottles" },
+    },
+  },
+};
+
+describe("product page handler", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("injects a real H1, description, and breadcrumb links into #root", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(response(SHELL_WITH_ROOT))
+      .mockResolvedValueOnce(response({ data: baseProduct }))
+      .mockResolvedValueOnce(response({ success: false }, 404));
+    vi.stubGlobal("fetch", fetchMock);
+    const res = createResponse();
+
+    await handler(
+      { query: { id: "42" }, headers: { host: "www.supermerch.com.au" } },
+      res,
+    );
+
+    expect(res.result.statusCode).toBe(200);
+    // Actually injected into #root, not left as an empty mount point.
+    expect(res.result.body).not.toContain('<div id="root"></div>');
+    expect(res.result.body).toContain('data-ssr-content="product"');
+    expect(res.result.body).toContain("<h1>Ocean Bottle</h1>");
+    expect(res.result.body).toContain("Reusable & insulated bottle");
+    expect(res.result.body).toContain('<nav aria-label="Breadcrumb">');
+    expect(res.result.body).toContain('<a href="/">Home</a>');
+    expect(res.result.body).toContain('<a href="/shop">Shop</a>');
+    // Current-page crumb (the product itself) has no link, matching the
+    // rendered pattern used for visible breadcrumbs elsewhere on the site.
+    expect(res.result.body).toContain("<span>Ocean Bottle</span>");
+  });
+
+  it("keeps the product's category consistent between the visible breadcrumb and the BreadcrumbList JSON-LD", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(response(SHELL_WITH_ROOT))
+      .mockResolvedValueOnce(response({ data: baseProduct }))
+      .mockResolvedValueOnce(response({ success: false }, 404));
+    vi.stubGlobal("fetch", fetchMock);
+    const res = createResponse();
+
+    await handler(
+      { query: { id: "42" }, headers: { host: "www.supermerch.com.au" } },
+      res,
+    );
+
+    const body = res.result.body;
+    expect(res.result.statusCode).toBe(200);
+
+    // Visible breadcrumb <a> for the category.
+    expect(body).toContain(
+      '<a href="/shop?category=Drink%20Bottles">Drink Bottles</a>',
+    );
+
+    // BreadcrumbList JSON-LD must reference the exact same category name and
+    // the exact same href — the visible crumb and the structured data must
+    // never disagree about the product's category.
+    const jsonLdMatches = [
+      ...body.matchAll(
+        /<script type="application\/ld\+json" data-sm-seo-jsonld="true">([\s\S]*?)<\/script>/g,
+      ),
+    ].map((match) => JSON.parse(match[1]));
+
+    const productSchema = jsonLdMatches.find((v) => v["@type"] === "Product");
+    const breadcrumbSchema = jsonLdMatches.find(
+      (v) => v["@type"] === "BreadcrumbList",
+    );
+
+    expect(productSchema.category).toBe("Drink Bottles");
+
+    const categoryCrumb = breadcrumbSchema.itemListElement.find(
+      (item) => item.name === "Drink Bottles",
+    );
+    expect(categoryCrumb).toBeDefined();
+    expect(categoryCrumb.item).toBe(
+      "https://www.supermerch.com.au/shop?category=Drink%20Bottles",
+    );
+  });
+
+  it("HTML-escapes a hostile/malicious product name and description before injecting into #root", async () => {
+    const hostileProduct = {
+      ...baseProduct,
+      product: {
+        ...baseProduct.product,
+        name: '<img src=x onerror=alert(1)>Mugs & "Steins"',
+        description:
+          "<script>alert('xss')</script>Great for outdoor events & fundraisers.",
+      },
+    };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(response(SHELL_WITH_ROOT))
+      .mockResolvedValueOnce(response({ data: hostileProduct }))
+      .mockResolvedValueOnce(response({ success: false }, 404));
+    vi.stubGlobal("fetch", fetchMock);
+    const res = createResponse();
+
+    await handler(
+      { query: { id: "43" }, headers: { host: "www.supermerch.com.au" } },
+      res,
+    );
+
+    const body = res.result.body;
+    expect(res.result.statusCode).toBe(200);
+    // cleanText() strips HTML tags from the source before anything is
+    // embedded, so no hostile <script> or <img onerror=...> tag can survive
+    // intact. The page's own JSON-LD <script type="application/ld+json">
+    // tags are expected and safe, so assert on the hostile payload
+    // specifically rather than banning "<script" outright.
+    expect(body).not.toContain("<script>alert");
+    expect(body.toLowerCase()).not.toContain("<img");
+    expect(body).not.toContain("onerror=");
+    // Every remaining <script> tag is one of our own trusted JSON-LD blocks.
+    const scriptOpenTags = body.match(/<script(?![^>]*application\/ld\+json)[^>]*>/gi) || [];
+    expect(scriptOpenTags).toEqual([]);
+    // The surviving text is HTML-entity-escaped wherever it's embedded.
+    expect(body).toContain("&amp;");
+    expect(body).toContain("&quot;Steins&quot;");
+    expect(body).toContain("Mugs &amp; &quot;Steins&quot;</h1>");
+  });
+
+  it("fails safely and still returns valid HTML when #root is missing from the page shell", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(response(SHELL_WITHOUT_ROOT))
+      .mockResolvedValueOnce(response({ data: baseProduct }))
+      .mockResolvedValueOnce(response({ success: false }, 404));
+    vi.stubGlobal("fetch", fetchMock);
+    const res = createResponse();
+
+    await expect(
+      handler(
+        { query: { id: "42" }, headers: { host: "www.supermerch.com.au" } },
+        res,
+      ),
+    ).resolves.not.toThrow();
+
+    expect(res.result.statusCode).toBe(200);
+    // Head tags still apply even with nothing to inject the body into.
+    expect(res.result.body).toContain(
+      "<title>Ocean Bottle | Custom Branded | Super Merch Australia</title>",
+    );
+    expect(res.result.body).toContain("</head>");
+    expect(res.result.body).toContain("</html>");
+    // No corruption from the failed injection attempt.
+    expect(res.result.body).not.toContain('id="root">undefined');
+    expect(res.result.body).not.toContain("[object Object]");
+  });
+});

--- a/src/__tests__/productPageHandler.test.js
+++ b/src/__tests__/productPageHandler.test.js
@@ -179,6 +179,42 @@ describe("product page handler", () => {
     expect(breadcrumbSchema.itemListElement).toHaveLength(3);
   });
 
+  it("resolves the category label and its type_id from the same source object, never mixing the two", async () => {
+    const mismatchedTaxonomyProduct = {
+      ...baseProduct,
+      product: {
+        ...baseProduct.product,
+        categorisation: {
+          // Has a name but no ID -- must not be used for anything.
+          promodata_product_type: { type_name: "Eco Drinkware" },
+          // Has both a name and an ID -- this is the only valid source.
+          product_type: { type_name: "Drink Bottles", type_id: "PE-02" },
+        },
+      },
+    };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(response(SHELL_WITH_ROOT))
+      .mockResolvedValueOnce(response({ data: mismatchedTaxonomyProduct }))
+      .mockResolvedValueOnce(response({ success: false }, 404));
+    vi.stubGlobal("fetch", fetchMock);
+    const res = createResponse();
+
+    await handler(
+      { query: { id: "45" }, headers: { host: "www.supermerch.com.au" } },
+      res,
+    );
+
+    const body = res.result.body;
+    expect(res.result.statusCode).toBe(200);
+    // The label and ID must both come from product_type, the same object --
+    // never "Eco Drinkware" (promodata's name) paired with "PE-02"
+    // (product_type's ID), which would describe one category while linking
+    // to another.
+    expect(body).toContain('<a href="/shop?category=PE-02">Drink Bottles</a>');
+    expect(body).not.toContain("Eco Drinkware");
+  });
+
   it("HTML-escapes a hostile/malicious product name and description before injecting into #root", async () => {
     const hostileProduct = {
       ...baseProduct,

--- a/src/__tests__/productPageHandler.test.js
+++ b/src/__tests__/productPageHandler.test.js
@@ -215,6 +215,42 @@ describe("product page handler", () => {
     expect(body).not.toContain("Eco Drinkware");
   });
 
+  it("never pairs a type_id with a label from a different source when that same object has no type_name", async () => {
+    const idOnlyTaxonomyProduct = {
+      ...baseProduct,
+      product: {
+        ...baseProduct.product,
+        categorisation: {
+          // Has an ID but no name -- selecting on type_id alone would keep
+          // this object for the ID while falling through to
+          // supplier_category for the label, recreating the exact
+          // label/ID mismatch this fix exists to prevent.
+          promodata_product_type: { type_id: "PE-02" },
+          supplier_category: "Drinkware",
+        },
+      },
+    };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(response(SHELL_WITH_ROOT))
+      .mockResolvedValueOnce(response({ data: idOnlyTaxonomyProduct }))
+      .mockResolvedValueOnce(response({ success: false }, 404));
+    vi.stubGlobal("fetch", fetchMock);
+    const res = createResponse();
+
+    await handler(
+      { query: { id: "46" }, headers: { host: "www.supermerch.com.au" } },
+      res,
+    );
+
+    const body = res.result.body;
+    expect(res.result.statusCode).toBe(200);
+    // No object has both fields, so no category crumb at all -- never
+    // "Drinkware" (supplier_category's label) linked to "PE-02"
+    // (promodata_product_type's ID).
+    expect(body).not.toContain("shop?category=");
+  });
+
   it("HTML-escapes a hostile/malicious product name and description before injecting into #root", async () => {
     const hostileProduct = {
       ...baseProduct,

--- a/src/__tests__/productPageHandler.test.js
+++ b/src/__tests__/productPageHandler.test.js
@@ -49,7 +49,7 @@ const baseProduct = {
     slug: "ocean-bottle",
     description: "<p>Reusable &amp; insulated bottle for the outdoors.</p>",
     categorisation: {
-      promodata_product_type: { type_name: "Drink Bottles" },
+      promodata_product_type: { type_name: "Drink Bottles", type_id: "PE-02" },
     },
   },
 };
@@ -87,7 +87,7 @@ describe("product page handler", () => {
     expect(res.result.body).toContain("<span>Ocean Bottle</span>");
   });
 
-  it("keeps the product's category consistent between the visible breadcrumb and the BreadcrumbList JSON-LD", async () => {
+  it("keeps the product's category consistent between the visible breadcrumb and the BreadcrumbList JSON-LD, and links use the real type_id, not the display label", async () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(response(SHELL_WITH_ROOT))
@@ -104,10 +104,12 @@ describe("product page handler", () => {
     const body = res.result.body;
     expect(res.result.statusCode).toBe(200);
 
-    // Visible breadcrumb <a> for the category.
-    expect(body).toContain(
-      '<a href="/shop?category=Drink%20Bottles">Drink Bottles</a>',
-    );
+    // Visible breadcrumb <a> for the category: Cards.jsx treats the
+    // ?category= value as a productTypeId sent straight to the backend as
+    // product_type_ids, so the URL must carry the real type_id ("PE-02"),
+    // never the human-readable label -- the label is display text only.
+    expect(body).toContain('<a href="/shop?category=PE-02">Drink Bottles</a>');
+    expect(body).not.toContain("category=Drink");
 
     // BreadcrumbList JSON-LD must reference the exact same category name and
     // the exact same href — the visible crumb and the structured data must
@@ -130,8 +132,51 @@ describe("product page handler", () => {
     );
     expect(categoryCrumb).toBeDefined();
     expect(categoryCrumb.item).toBe(
-      "https://www.supermerch.com.au/shop?category=Drink%20Bottles",
+      "https://www.supermerch.com.au/shop?category=PE-02",
     );
+  });
+
+  it("omits the category breadcrumb link entirely when no reliable type_id is available, rather than publishing a broken URL", async () => {
+    const productWithNoTypeId = {
+      ...baseProduct,
+      product: {
+        ...baseProduct.product,
+        // supplier_category has no ID equivalent anywhere in the codebase --
+        // a category resolved only from this fallback must not get a link.
+        categorisation: { supplier_category: "Drinkware" },
+      },
+    };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(response(SHELL_WITH_ROOT))
+      .mockResolvedValueOnce(response({ data: productWithNoTypeId }))
+      .mockResolvedValueOnce(response({ success: false }, 404));
+    vi.stubGlobal("fetch", fetchMock);
+    const res = createResponse();
+
+    await handler(
+      { query: { id: "44" }, headers: { host: "www.supermerch.com.au" } },
+      res,
+    );
+
+    const body = res.result.body;
+    expect(res.result.statusCode).toBe(200);
+    // No category breadcrumb link -- "Drinkware" can still legitimately
+    // appear elsewhere (e.g. the Product schema's plain category field,
+    // which needs no URL), but nothing may link to a category with no
+    // real type_id behind it.
+    expect(body).not.toContain("shop?category=");
+
+    const jsonLdMatches = [
+      ...body.matchAll(
+        /<script type="application\/ld\+json" data-sm-seo-jsonld="true">([\s\S]*?)<\/script>/g,
+      ),
+    ].map((match) => JSON.parse(match[1]));
+    const breadcrumbSchema = jsonLdMatches.find(
+      (v) => v["@type"] === "BreadcrumbList",
+    );
+    // Home, Shop, and the product itself -- no category crumb in between.
+    expect(breadcrumbSchema.itemListElement).toHaveLength(3);
   });
 
   it("HTML-escapes a hostile/malicious product name and description before injecting into #root", async () => {

--- a/src/__tests__/routeSeoShopFilters.test.jsx
+++ b/src/__tests__/routeSeoShopFilters.test.jsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+
+/**
+ * RouteSeo drives the client-side <meta name="robots"> tag for /shop. Faceted
+ * URLs (color, size, price, etc.) must get noindex,follow so search engines
+ * don't index combinatorial duplicate variants, while the canonical /shop and
+ * /shop?category=X views must stay indexable. This must match the
+ * server-side decision in api/seo-page.js (see hasShopFilterParams there).
+ */
+
+import { cleanup, render } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it } from "vitest";
+import RouteSeo from "../components/Common/RouteSeo";
+
+afterEach(() => {
+  cleanup();
+  document.head
+    .querySelectorAll('meta[data-sm-seo="true"]')
+    .forEach((node) => node.remove());
+});
+
+const robotsContent = () =>
+  document.head.querySelector('meta[name="robots"]')?.getAttribute("content");
+
+const renderAt = (path) =>
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <RouteSeo />
+    </MemoryRouter>,
+  );
+
+describe("RouteSeo client-side robots tag for /shop", () => {
+  it("keeps the plain /shop page indexable", () => {
+    renderAt("/shop");
+    expect(robotsContent()).toBe("index, follow");
+  });
+
+  it("keeps a category view of /shop indexable", () => {
+    renderAt("/shop?category=wooden-pens");
+    expect(robotsContent()).toBe("index, follow");
+  });
+
+  it("keeps benign params (page/sort/view/utm/gclid) indexable", () => {
+    renderAt("/shop?category=wooden-pens&page=2&sort=price&view=grid&utm_source=x&gclid=1");
+    expect(robotsContent()).toBe("index, follow");
+  });
+
+  it("noindexes /shop with a color facet param", () => {
+    renderAt("/shop?color=blue");
+    expect(robotsContent()).toBe("noindex, follow");
+  });
+
+  it("noindexes /shop with a size facet param", () => {
+    renderAt("/shop?size=large");
+    expect(robotsContent()).toBe("noindex, follow");
+  });
+
+  it("noindexes /shop with a price facet param even alongside a category", () => {
+    renderAt("/shop?category=wooden-pens&priceMin=10&priceMax=50");
+    expect(robotsContent()).toBe("noindex, follow");
+  });
+});

--- a/src/__tests__/routeSeoShopFilters.test.jsx
+++ b/src/__tests__/routeSeoShopFilters.test.jsx
@@ -24,6 +24,9 @@ afterEach(() => {
 const robotsContent = () =>
   document.head.querySelector('meta[name="robots"]')?.getAttribute("content");
 
+const canonicalHref = () =>
+  document.head.querySelector('link[rel="canonical"]')?.getAttribute("href");
+
 const renderAt = (path) =>
   render(
     <MemoryRouter initialEntries={[path]}>
@@ -31,19 +34,22 @@ const renderAt = (path) =>
     </MemoryRouter>,
   );
 
+// PE-02 is a real leaf category ID (Drink Bottles) in
+// authoritative-category-ids.json -- used wherever a test needs a genuinely
+// valid category, as opposed to "wooden-pens", which is not a real ID.
 describe("RouteSeo client-side robots tag for /shop", () => {
   it("keeps the plain /shop page indexable", () => {
     renderAt("/shop");
     expect(robotsContent()).toBe("index, follow");
   });
 
-  it("keeps a category view of /shop indexable", () => {
-    renderAt("/shop?category=wooden-pens");
+  it("keeps a real category view of /shop indexable", () => {
+    renderAt("/shop?category=PE-02");
     expect(robotsContent()).toBe("index, follow");
   });
 
   it("keeps benign params (page/sort/view/utm/gclid) indexable", () => {
-    renderAt("/shop?category=wooden-pens&page=2&sort=price&view=grid&utm_source=x&gclid=1");
+    renderAt("/shop?category=PE-02&page=2&sort=price&view=grid&utm_source=x&gclid=1");
     expect(robotsContent()).toBe("index, follow");
   });
 
@@ -58,7 +64,45 @@ describe("RouteSeo client-side robots tag for /shop", () => {
   });
 
   it("noindexes /shop with a price facet param even alongside a category", () => {
-    renderAt("/shop?category=wooden-pens&priceMin=10&priceMax=50");
+    renderAt("/shop?category=PE-02&priceMin=10&priceMax=50");
+    expect(robotsContent()).toBe("noindex, follow");
+  });
+
+  it("noindexes /shop with a category value that isn't a real leaf/parent ID", () => {
+    renderAt("/shop?category=wooden-pens");
+    expect(robotsContent()).toBe("noindex, follow");
+  });
+});
+
+// Must stay in parity with the server-side canonical decision in
+// api/seo-page.js -- both consume the same shared isValidCategoryId() check,
+// so hydration can never contradict the tags the server already sent.
+describe("RouteSeo client-side canonical tag for /shop", () => {
+  it("/shop -> self-canonical, indexable", () => {
+    renderAt("/shop");
+    expect(canonicalHref()).toBe("https://www.supermerch.com.au/shop");
+    expect(robotsContent()).toBe("index, follow");
+  });
+
+  it("/shop?category=<valid> -> self-canonical (same category URL), indexable", () => {
+    renderAt("/shop?category=PE-02");
+    expect(canonicalHref()).toBe(
+      "https://www.supermerch.com.au/shop?category=PE-02",
+    );
+    expect(robotsContent()).toBe("index, follow");
+  });
+
+  it("/shop?category=<invalid> -> canonicalizes to plain /shop, noindex", () => {
+    renderAt("/shop?category=wooden-pens");
+    expect(canonicalHref()).toBe("https://www.supermerch.com.au/shop");
+    expect(robotsContent()).toBe("noindex, follow");
+  });
+
+  it("/shop?category=<valid>&<facet> -> canonicalizes to the category-only URL, noindex", () => {
+    renderAt("/shop?category=PE-02&color=blue");
+    expect(canonicalHref()).toBe(
+      "https://www.supermerch.com.au/shop?category=PE-02",
+    );
     expect(robotsContent()).toBe("noindex, follow");
   });
 });

--- a/src/__tests__/seoPageHandler.test.js
+++ b/src/__tests__/seoPageHandler.test.js
@@ -26,6 +26,19 @@ const createResponse = () => {
   };
 };
 
+// Real app shell shape: a #root mount point the SPA hydrates into. The
+// injection logic (injectBody in api/seo-page.js) only replaces content
+// inside <div id="root"></div> — a fixture without it would let the handler
+// silently no-op on body injection while every assertion on <head> tags
+// still passes, hiding a broken injectBody() completely.
+const SHELL_WITH_ROOT =
+  '<html><head><title>Fallback</title></head><body><div id="root"></div></body></html>';
+
+// Used to prove the handler fails safely (doesn't throw, doesn't corrupt the
+// response) if the app shell is ever missing its mount point.
+const SHELL_WITHOUT_ROOT =
+  "<html><head><title>Fallback</title></head><body></body></html>";
+
 describe("SEO page handler", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -34,9 +47,7 @@ describe("SEO page handler", () => {
   it("renders the selected category record and keeps only its canonical query", async () => {
     const fetchMock = vi
       .fn()
-      .mockResolvedValueOnce(
-        response("<html><head><title>Fallback</title></head><body></body></html>"),
-      )
+      .mockResolvedValueOnce(response(SHELL_WITH_ROOT))
       .mockResolvedValueOnce(
         response({
           success: true,
@@ -78,9 +89,7 @@ describe("SEO page handler", () => {
   it("canonicalises an unknown category to the general shop", async () => {
     const fetchMock = vi
       .fn()
-      .mockResolvedValueOnce(
-        response("<html><head><title>Fallback</title></head><body></body></html>"),
-      )
+      .mockResolvedValueOnce(response(SHELL_WITH_ROOT))
       .mockResolvedValueOnce(response({ success: false }, 404));
     vi.stubGlobal("fetch", fetchMock);
     const res = createResponse();
@@ -105,9 +114,7 @@ describe("SEO page handler", () => {
   it("adds organisation structured data to the homepage", async () => {
     const fetchMock = vi
       .fn()
-      .mockResolvedValueOnce(
-        response("<html><head><title>Fallback</title></head><body></body></html>"),
-      )
+      .mockResolvedValueOnce(response(SHELL_WITH_ROOT))
       .mockResolvedValueOnce(response({ success: false }, 404));
     vi.stubGlobal("fetch", fetchMock);
     const res = createResponse();
@@ -129,9 +136,7 @@ describe("SEO page handler", () => {
   it("noindexes thin blog posts", async () => {
     const fetchMock = vi
       .fn()
-      .mockResolvedValueOnce(
-        response("<html><head><title>Fallback</title></head><body></body></html>"),
-      )
+      .mockResolvedValueOnce(response(SHELL_WITH_ROOT))
       .mockResolvedValueOnce(
         response({
           data: {
@@ -157,5 +162,258 @@ describe("SEO page handler", () => {
     expect(res.result.body).toContain(
       '<meta name="robots" content="noindex, follow">',
     );
+  });
+
+  describe("#root body injection", () => {
+    it("injects a real, crawlable H1 and description for a static/CMS page into #root", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(response(SHELL_WITH_ROOT))
+        .mockResolvedValueOnce(response({ success: false }, 404));
+      vi.stubGlobal("fetch", fetchMock);
+      const res = createResponse();
+
+      await handler(
+        {
+          query: { path: "/about" },
+          headers: { host: "www.supermerch.com.au" },
+        },
+        res,
+      );
+
+      expect(res.result.statusCode).toBe(200);
+      // Injected inside #root, not left as an untouched empty mount point.
+      expect(res.result.body).not.toContain('<div id="root"></div>');
+      expect(res.result.body).toContain('<div id="root">');
+      expect(res.result.body).toContain('data-ssr-content="page"');
+      expect(res.result.body).toContain("<h1>About Super Merch Australia</h1>");
+      expect(res.result.body).toContain("Learn about Super Merch");
+    });
+
+    it("injects breadcrumb links for a category page, consistent with the visible Shop crumb", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(response(SHELL_WITH_ROOT))
+        .mockResolvedValueOnce(
+          response({
+            success: true,
+            data: {
+              metaTitle:
+                "Wooden Pens Promotional Products | Super Merch Australia",
+            },
+          }),
+        );
+      vi.stubGlobal("fetch", fetchMock);
+      const res = createResponse();
+
+      await handler(
+        {
+          query: { path: "/shop", category: "wooden-pens" },
+          headers: { host: "www.supermerch.com.au" },
+        },
+        res,
+      );
+
+      expect(res.result.statusCode).toBe(200);
+      expect(res.result.body).toContain('<nav aria-label="Breadcrumb">');
+      expect(res.result.body).toContain('<a href="/">Home</a>');
+      expect(res.result.body).toContain(
+        "<h1>Wooden Pens Promotional Products</h1>",
+      );
+    });
+
+    it("HTML-escapes a hostile/malicious blog title and content before injecting into #root", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(response(SHELL_WITH_ROOT))
+        .mockResolvedValueOnce(
+          response({
+            data: {
+              _id: "hostile-post",
+              title: '<img src=x onerror=alert(1)>Big "Sale" & <b>More</b>',
+              content:
+                "<script>alert('xss')</script>" +
+                "This blog post has plenty of real words in it so it clears the thin-content threshold and stays indexable, which means it must still be escaped safely. ".repeat(
+                  5,
+                ),
+            },
+          }),
+        )
+        .mockResolvedValueOnce(response({ success: false }, 404));
+      vi.stubGlobal("fetch", fetchMock);
+      const res = createResponse();
+
+      await handler(
+        {
+          query: { path: "/blogs/hostile-post" },
+          headers: { host: "www.supermerch.com.au" },
+        },
+        res,
+      );
+
+      expect(res.result.statusCode).toBe(200);
+      // No raw, executable markup anywhere in the response: cleanText()
+      // strips all HTML tags from the source before the result is ever
+      // embedded, so no <script> or <img onerror=...> tag can survive
+      // (the sanitizer removes the tag itself, not just its attributes).
+      expect(res.result.body.toLowerCase()).not.toContain("<script");
+      expect(res.result.body.toLowerCase()).not.toContain("<img");
+      expect(res.result.body).not.toContain("onerror=");
+      // The surviving text is safely HTML-entity-escaped wherever it's
+      // embedded (title, H1, breadcrumb, meta attributes).
+      expect(res.result.body).toContain("&amp;");
+      expect(res.result.body).toContain("&quot;Sale&quot;");
+      expect(res.result.body).toContain("<h1>Big &quot;Sale&quot; &amp; More</h1>");
+    });
+
+    it("fails safely and returns the untouched shell when #root is missing from the page shell", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(response(SHELL_WITHOUT_ROOT))
+        .mockResolvedValueOnce(response({ success: false }, 404));
+      vi.stubGlobal("fetch", fetchMock);
+      const res = createResponse();
+
+      await expect(
+        handler(
+          {
+            query: { path: "/about" },
+            headers: { host: "www.supermerch.com.au" },
+          },
+          res,
+        ),
+      ).resolves.not.toThrow();
+
+      // Head tags (title/meta/robots) still get applied even when body
+      // injection has nothing to attach to.
+      expect(res.result.statusCode).toBe(200);
+      expect(res.result.body).toContain("<title>About Super Merch Australia</title>");
+      expect(res.result.body).toContain("</head>");
+      expect(res.result.body).toContain("</html>");
+      // No corruption: the (missing) #root mount point is simply absent —
+      // never a broken/duplicated/partial tag.
+      expect(res.result.body).not.toContain('id="root">undefined');
+      expect(res.result.body).not.toContain("[object Object]");
+    });
+  });
+
+  describe("faceted /shop noindex handling", () => {
+    it("noindexes a /shop URL with a color facet param", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(response(SHELL_WITH_ROOT))
+        .mockResolvedValueOnce(response({ success: false }, 404));
+      vi.stubGlobal("fetch", fetchMock);
+      const res = createResponse();
+
+      await handler(
+        {
+          query: { path: "/shop", color: "blue" },
+          headers: { host: "www.supermerch.com.au" },
+        },
+        res,
+      );
+
+      expect(res.result.statusCode).toBe(200);
+      expect(res.result.body).toContain(
+        '<meta name="robots" content="noindex, follow">',
+      );
+    });
+
+    it("noindexes a /shop URL with a price-range facet param even with a category selected", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(response(SHELL_WITH_ROOT))
+        .mockResolvedValueOnce(response({ success: false }, 404));
+      vi.stubGlobal("fetch", fetchMock);
+      const res = createResponse();
+
+      await handler(
+        {
+          query: { path: "/shop", category: "wooden-pens", priceMin: "10" },
+          headers: { host: "www.supermerch.com.au" },
+        },
+        res,
+      );
+
+      expect(res.result.statusCode).toBe(200);
+      expect(res.result.body).toContain(
+        '<meta name="robots" content="noindex, follow">',
+      );
+    });
+
+    it("keeps the plain /shop URL indexable", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(response(SHELL_WITH_ROOT))
+        .mockResolvedValueOnce(response({ success: false }, 404));
+      vi.stubGlobal("fetch", fetchMock);
+      const res = createResponse();
+
+      await handler(
+        {
+          query: { path: "/shop" },
+          headers: { host: "www.supermerch.com.au" },
+        },
+        res,
+      );
+
+      expect(res.result.statusCode).toBe(200);
+      expect(res.result.body).toContain(
+        '<meta name="robots" content="index, follow">',
+      );
+    });
+
+    it("keeps a /shop?category=X URL indexable", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(response(SHELL_WITH_ROOT))
+        .mockResolvedValueOnce(response({ success: false }, 404));
+      vi.stubGlobal("fetch", fetchMock);
+      const res = createResponse();
+
+      await handler(
+        {
+          query: { path: "/shop", category: "wooden-pens" },
+          headers: { host: "www.supermerch.com.au" },
+        },
+        res,
+      );
+
+      expect(res.result.statusCode).toBe(200);
+      expect(res.result.body).toContain(
+        '<meta name="robots" content="index, follow">',
+      );
+    });
+
+    it("keeps benign params (page/sort/view/utm/gclid) indexable", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(response(SHELL_WITH_ROOT))
+        .mockResolvedValueOnce(response({ success: false }, 404));
+      vi.stubGlobal("fetch", fetchMock);
+      const res = createResponse();
+
+      await handler(
+        {
+          query: {
+            path: "/shop",
+            category: "wooden-pens",
+            page: "2",
+            sort: "price",
+            view: "grid",
+            utm_source: "newsletter",
+            gclid: "abc123",
+          },
+          headers: { host: "www.supermerch.com.au" },
+        },
+        res,
+      );
+
+      expect(res.result.statusCode).toBe(200);
+      expect(res.result.body).toContain(
+        '<meta name="robots" content="index, follow">',
+      );
+    });
   });
 });

--- a/src/__tests__/seoPageHandler.test.js
+++ b/src/__tests__/seoPageHandler.test.js
@@ -197,6 +197,10 @@ describe("SEO page handler", () => {
     expect(res.result.body).toContain(
       '<meta name="robots" content="noindex, follow">',
     );
+    // Proves the override endpoint was never even queried for an invalid
+    // category, not just that its response was ignored -- only the shell
+    // fetch (call 1) should have happened.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it("adds organisation structured data to the homepage", async () => {

--- a/src/__tests__/seoPageHandler.test.js
+++ b/src/__tests__/seoPageHandler.test.js
@@ -86,7 +86,14 @@ describe("SEO page handler", () => {
     );
   });
 
-  it("canonicalises an unknown category to the general shop", async () => {
+  it("stays self-canonical for a category with no admin SEO override configured", async () => {
+    // Whether an admin has configured a custom SEO override for a category
+    // is unrelated to whether that category's own URL is the canonical
+    // page. Collapsing to plain "/shop" here for every un-overridden
+    // category (the vast majority of them) contradicted the robots tag
+    // ("index, follow") set on this exact same URL just above in the
+    // handler, and disagreed with the client-side canonical logic in
+    // src/utils/shopSeo.js, which has never gated on override existence.
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(response(SHELL_WITH_ROOT))
@@ -107,7 +114,7 @@ describe("SEO page handler", () => {
 
     expect(res.result.statusCode).toBe(200);
     expect(res.result.body).toContain(
-      '<link rel="canonical" href="https://www.supermerch.com.au/shop">',
+      '<link rel="canonical" href="https://www.supermerch.com.au/shop?category=does-not-exist-xyz">',
     );
   });
 

--- a/src/__tests__/seoPageHandler.test.js
+++ b/src/__tests__/seoPageHandler.test.js
@@ -86,7 +86,7 @@ describe("SEO page handler", () => {
     );
   });
 
-  it("stays self-canonical for a category with no admin SEO override configured", async () => {
+  it("stays self-canonical and indexable for a real category with no admin SEO override configured", async () => {
     // Whether an admin has configured a custom SEO override for a category
     // is unrelated to whether that category's own URL is the canonical
     // page. Collapsing to plain "/shop" here for every un-overridden
@@ -94,6 +94,41 @@ describe("SEO page handler", () => {
     // ("index, follow") set on this exact same URL just above in the
     // handler, and disagreed with the client-side canonical logic in
     // src/utils/shopSeo.js, which has never gated on override existence.
+    // "PE-02" is a real leaf category ID (Drink Bottles) in the
+    // authoritative category inventory.
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(response(SHELL_WITH_ROOT))
+      .mockResolvedValueOnce(response({ success: false }, 404));
+    vi.stubGlobal("fetch", fetchMock);
+    const res = createResponse();
+
+    await handler(
+      {
+        query: {
+          path: "/shop",
+          category: "PE-02",
+        },
+        headers: { host: "www.supermerch.com.au" },
+      },
+      res,
+    );
+
+    expect(res.result.statusCode).toBe(200);
+    expect(res.result.body).toContain(
+      '<link rel="canonical" href="https://www.supermerch.com.au/shop?category=PE-02">',
+    );
+    expect(res.result.body).toContain(
+      '<meta name="robots" content="index, follow">',
+    );
+  });
+
+  it("canonicalizes an invalid/nonexistent category to plain /shop and keeps it out of the index", async () => {
+    // A category value that isn't a real leaf/parent ID must never become
+    // self-canonical or indexable -- that would let unlimited junk category
+    // URLs consume crawl budget and appear as thin/duplicate pages, which
+    // is the exact problem this endpoint exists to fix, not reintroduce.
+    // Admin SEO override presence is never used as the validity signal.
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(response(SHELL_WITH_ROOT))
@@ -114,7 +149,10 @@ describe("SEO page handler", () => {
 
     expect(res.result.statusCode).toBe(200);
     expect(res.result.body).toContain(
-      '<link rel="canonical" href="https://www.supermerch.com.au/shop?category=does-not-exist-xyz">',
+      '<link rel="canonical" href="https://www.supermerch.com.au/shop">',
+    );
+    expect(res.result.body).toContain(
+      '<meta name="robots" content="noindex, follow">',
     );
   });
 
@@ -372,6 +410,9 @@ describe("SEO page handler", () => {
     });
 
     it("keeps a /shop?category=X URL indexable", async () => {
+      // "PE-02" is a real leaf category ID (Drink Bottles) in the
+      // authoritative category inventory -- indexability now depends on
+      // that, not just on the absence of facet params.
       const fetchMock = vi
         .fn()
         .mockResolvedValueOnce(response(SHELL_WITH_ROOT))
@@ -381,7 +422,7 @@ describe("SEO page handler", () => {
 
       await handler(
         {
-          query: { path: "/shop", category: "wooden-pens" },
+          query: { path: "/shop", category: "PE-02" },
           headers: { host: "www.supermerch.com.au" },
         },
         res,
@@ -405,7 +446,7 @@ describe("SEO page handler", () => {
         {
           query: {
             path: "/shop",
-            category: "wooden-pens",
+            category: "PE-02",
             page: "2",
             sort: "price",
             view: "grid",

--- a/src/__tests__/seoPageHandler.test.js
+++ b/src/__tests__/seoPageHandler.test.js
@@ -45,6 +45,9 @@ describe("SEO page handler", () => {
   });
 
   it("renders the selected category record and keeps only its canonical query", async () => {
+    // PE-02 is a real leaf category ID (Drink Bottles) in the authoritative
+    // category inventory -- an admin SEO override is only ever consulted for
+    // a valid category, so this test uses a real one.
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(response(SHELL_WITH_ROOT))
@@ -53,9 +56,9 @@ describe("SEO page handler", () => {
           success: true,
           data: {
             metaTitle:
-              "Wooden Pens Promotional Products | Super Merch Australia",
+              "Drink Bottles Promotional Products | Super Merch Australia",
             canonicalUrl:
-              "https://supermerch.com.au/shop?category=wooden-pens&page=2&utm_source=test",
+              "https://supermerch.com.au/shop?category=PE-02&page=2&utm_source=test",
           },
         }),
       );
@@ -66,7 +69,7 @@ describe("SEO page handler", () => {
       {
         query: {
           path: "/shop",
-          category: "wooden-pens",
+          category: "PE-02",
           page: "2",
         },
         headers: { host: "www.supermerch.com.au" },
@@ -75,14 +78,14 @@ describe("SEO page handler", () => {
     );
 
     expect(fetchMock.mock.calls[1][0]).toContain(
-      "/api/seo-meta/by-entity/category/wooden-pens",
+      "/api/seo-meta/by-entity/category/PE-02",
     );
     expect(res.result.statusCode).toBe(200);
     expect(res.result.body).toContain(
-      "<title>Wooden Pens Promotional Products | Super Merch Australia</title>",
+      "<title>Drink Bottles Promotional Products | Super Merch Australia</title>",
     );
     expect(res.result.body).toContain(
-      '<link rel="canonical" href="https://www.supermerch.com.au/shop?category=wooden-pens">',
+      '<link rel="canonical" href="https://www.supermerch.com.au/shop?category=PE-02">',
     );
   });
 
@@ -133,6 +136,46 @@ describe("SEO page handler", () => {
       .fn()
       .mockResolvedValueOnce(response(SHELL_WITH_ROOT))
       .mockResolvedValueOnce(response({ success: false }, 404));
+    vi.stubGlobal("fetch", fetchMock);
+    const res = createResponse();
+
+    await handler(
+      {
+        query: {
+          path: "/shop",
+          category: "does-not-exist-xyz",
+        },
+        headers: { host: "www.supermerch.com.au" },
+      },
+      res,
+    );
+
+    expect(res.result.statusCode).toBe(200);
+    expect(res.result.body).toContain(
+      '<link rel="canonical" href="https://www.supermerch.com.au/shop">',
+    );
+    expect(res.result.body).toContain(
+      '<meta name="robots" content="noindex, follow">',
+    );
+  });
+
+  it("ignores a stale/mistaken admin SEO override for an invalid category, rather than letting its canonicalUrl win", async () => {
+    // If a category is ever removed, or an admin previously created an
+    // override keyed to a bad value, that override must never resurrect an
+    // invalid category as self-canonical/indexable -- the validity check
+    // must win regardless of what admin data happens to exist for this ID.
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(response(SHELL_WITH_ROOT))
+      .mockResolvedValueOnce(
+        response({
+          success: true,
+          data: {
+            canonicalUrl:
+              "https://www.supermerch.com.au/shop?category=does-not-exist-xyz",
+          },
+        }),
+      );
     vi.stubGlobal("fetch", fetchMock);
     const res = createResponse();
 
@@ -236,6 +279,9 @@ describe("SEO page handler", () => {
     });
 
     it("injects breadcrumb links for a category page, consistent with the visible Shop crumb", async () => {
+      // PE-02 is a real leaf category ID (Drink Bottles) -- the admin
+      // override this test exercises is only ever consulted for a valid
+      // category.
       const fetchMock = vi
         .fn()
         .mockResolvedValueOnce(response(SHELL_WITH_ROOT))
@@ -244,7 +290,7 @@ describe("SEO page handler", () => {
             success: true,
             data: {
               metaTitle:
-                "Wooden Pens Promotional Products | Super Merch Australia",
+                "Drink Bottles Promotional Products | Super Merch Australia",
             },
           }),
         );
@@ -253,7 +299,7 @@ describe("SEO page handler", () => {
 
       await handler(
         {
-          query: { path: "/shop", category: "wooden-pens" },
+          query: { path: "/shop", category: "PE-02" },
           headers: { host: "www.supermerch.com.au" },
         },
         res,
@@ -263,7 +309,7 @@ describe("SEO page handler", () => {
       expect(res.result.body).toContain('<nav aria-label="Breadcrumb">');
       expect(res.result.body).toContain('<a href="/">Home</a>');
       expect(res.result.body).toContain(
-        "<h1>Wooden Pens Promotional Products</h1>",
+        "<h1>Drink Bottles Promotional Products</h1>",
       );
     });
 

--- a/src/components/Common/RouteSeo.jsx
+++ b/src/components/Common/RouteSeo.jsx
@@ -74,22 +74,34 @@ const RouteSeo = () => {
     "/shop": {
       entityType: "category",
       entityId: shopSeo.entityId,
-      canonicalUrlWhenSeoMissing:
-        shopSeo.entityId === "shop" ? undefined : `${SITE_URL}/shop`,
+      // A category value that isn't a real leaf/parent ID (typos, arbitrary
+      // input) canonicalizes to plain /shop and stays out of the index --
+      // same rule api/seo-page.js applies server-side, via the same shared
+      // isValidCategoryId() check, so hydration can never contradict it.
+      // forceCanonicalUrl wins over any admin SEO override for this entity,
+      // matching the server, which ignores overrides for invalid categories.
+      forceCanonicalUrl: shopSeo.isValidCategory
+        ? undefined
+        : `${SITE_URL}/shop`,
+      canonicalUrlWhenSeoMissing: shopSeo.isValidCategory
+        ? undefined
+        : `${SITE_URL}/shop`,
       fallback: {
         ...makeFallback({
           title: "Shop Promotional Products | Super Merch Australia",
           description: "Browse branded promotional products, custom merchandise, and business giveaways.",
           keywords: "shop promotional products, branded merchandise australia, business giveaways",
-          path: shopSeo.canonicalPath,
+          path: shopSeo.isValidCategory ? shopSeo.canonicalPath : "/shop",
         }),
         // Faceted/filtered /shop URLs (color, size, price, etc.) are thin,
-        // largely duplicate variants of the canonical category view — keep
-        // them out of the index while /shop and /shop?category=X stay
-        // indexable. Must match the server-side robots tag in api/seo-page.js.
-        robots: hasShopFilterParams(location.search)
-          ? "noindex, follow"
-          : "index, follow",
+        // largely duplicate variants of the canonical category view, and an
+        // invalid category value is never indexable -- keep both out of the
+        // index while /shop and /shop?category=<valid> stay indexable. Must
+        // match the server-side robots tag in api/seo-page.js.
+        robots:
+          hasShopFilterParams(location.search) || !shopSeo.isValidCategory
+            ? "noindex, follow"
+            : "index, follow",
       },
     },
     "/about": {

--- a/src/components/Common/RouteSeo.jsx
+++ b/src/components/Common/RouteSeo.jsx
@@ -1,20 +1,12 @@
 import { useLocation } from "react-router-dom";
 import SeoHelmet from "./SeoHelmet";
-import { getShopSeoContext } from "../../utils/shopSeo";
+import { getShopSeoContext, hasShopFilterParams } from "../../utils/shopSeo";
 
 const SITE_URL = "https://www.supermerch.com.au";
 const DEFAULT_IMAGE = `${SITE_URL}/logo-teal.png`;
-const ORGANIZATION_SCHEMA = {
-  "@context": "https://schema.org",
-  "@type": "Organization",
-  "@id": `${SITE_URL}/#organization`,
-  name: "Super Merch",
-  url: `${SITE_URL}/`,
-  logo: DEFAULT_IMAGE,
-  email: "Info@supermerch.com.au",
-  telephone: "+61466468528",
-  areaServed: "AU",
-};
+// Organization/WebSite structured data is fixed, non-dynamic content — it now
+// ships as a static <script type="application/ld+json"> block in index.html
+// so it's present in the raw HTML with no JS required. Do not re-add it here.
 
 const makeFallback = ({ title, description, keywords, path, ogType = "website" }) => ({
   title,
@@ -66,7 +58,6 @@ const RouteSeo = () => {
       <SeoHelmet
         entityType="cmsPage"
         entityId="home"
-        structuredData={[ORGANIZATION_SCHEMA]}
         fallback={makeFallback({
           title: "Super Merch Australia | Promotional Products & Custom Merchandise",
           description:
@@ -85,12 +76,21 @@ const RouteSeo = () => {
       entityId: shopSeo.entityId,
       canonicalUrlWhenSeoMissing:
         shopSeo.entityId === "shop" ? undefined : `${SITE_URL}/shop`,
-      fallback: makeFallback({
-        title: "Shop Promotional Products | Super Merch Australia",
-        description: "Browse branded promotional products, custom merchandise, and business giveaways.",
-        keywords: "shop promotional products, branded merchandise australia, business giveaways",
-        path: shopSeo.canonicalPath,
-      }),
+      fallback: {
+        ...makeFallback({
+          title: "Shop Promotional Products | Super Merch Australia",
+          description: "Browse branded promotional products, custom merchandise, and business giveaways.",
+          keywords: "shop promotional products, branded merchandise australia, business giveaways",
+          path: shopSeo.canonicalPath,
+        }),
+        // Faceted/filtered /shop URLs (color, size, price, etc.) are thin,
+        // largely duplicate variants of the canonical category view — keep
+        // them out of the index while /shop and /shop?category=X stay
+        // indexable. Must match the server-side robots tag in api/seo-page.js.
+        robots: hasShopFilterParams(location.search)
+          ? "noindex, follow"
+          : "index, follow",
+      },
     },
     "/about": {
       entityType: "cmsPage",

--- a/src/components/product/ProductDetails/index.jsx
+++ b/src/components/product/ProductDetails/index.jsx
@@ -1589,7 +1589,7 @@ const ProductDetails = () => {
             <div className="flex justify-between items-center md:flex-row flex-col">
               <div className="w-full">
                 <div className="flex items-start justify-between gap-3">
-                  <h2
+                  <h1
                     className={`text-2xl flex-1 min-w-0 ${product?.name ? "font-bold" : "font-medium"
                       } cursor-pointer transition-colors capitalize`}
                     onClick={handleHeadingClick}
@@ -1603,7 +1603,7 @@ const ProductDetails = () => {
                     aria-label="Product name - Press Shift+A to view supplier information"
                   >
                     {product?.name}
-                  </h2>
+                  </h1>
                   <Tooltip
                     title={
                       isFavourited

--- a/src/utils/categoryValidity.js
+++ b/src/utils/categoryValidity.js
@@ -1,0 +1,16 @@
+import categoryData from "../../scripts/category-finder/authoritative-category-ids.json" with { type: "json" };
+
+// Single source of truth for "is this a real leaf/parent category ID",
+// shared by the client (src/utils/shopSeo.js, RouteSeo.jsx) and the
+// api/seo-page.js serverless function, so both sides can never drift out of
+// sync on which /shop?category=X values are indexable/self-canonical.
+// Browser-compatible: no node:fs or other server-only APIs, since this file
+// is bundled into the client as well.
+const { leaves = [], parents = [] } = categoryData;
+
+export const VALID_CATEGORY_IDS = new Set(
+  [...leaves, ...parents].map((item) => item.id),
+);
+
+export const isValidCategoryId = (categoryId) =>
+  Boolean(categoryId) && VALID_CATEGORY_IDS.has(categoryId);

--- a/src/utils/shopSeo.js
+++ b/src/utils/shopSeo.js
@@ -1,3 +1,5 @@
+import { isValidCategoryId } from "./categoryValidity";
+
 export const getShopSeoContext = (search = "") => {
   const params = new URLSearchParams(search);
   const category = params.get("category")?.trim() || "";
@@ -7,6 +9,10 @@ export const getShopSeoContext = (search = "") => {
     canonicalPath: category
       ? `/shop?category=${encodeURIComponent(category)}`
       : "/shop",
+    // Plain /shop (no category) is always a real, indexable page. A
+    // category value only counts as valid when it's a real leaf/parent
+    // product-type ID -- must match api/seo-page.js's server-side check.
+    isValidCategory: category ? isValidCategoryId(category) : true,
   };
 };
 

--- a/src/utils/shopSeo.js
+++ b/src/utils/shopSeo.js
@@ -10,3 +10,29 @@ export const getShopSeoContext = (search = "") => {
   };
 };
 
+// Query params that don't create a distinct, thin/duplicate variant of a
+// /shop page: `category` selects the canonical category view itself, and the
+// rest are stripped from the canonical URL anyway (see canonicalUrl.js).
+const BENIGN_SHOP_PARAMS = new Set([
+  "category",
+  "page",
+  "sort",
+  "view",
+  "gclid",
+  "fbclid",
+]);
+
+/**
+ * True when /shop has facet/filter params beyond the ones above (e.g.
+ * color, size, price range) — combinations of these create combinatorial,
+ * largely duplicate content and should be kept out of the index while the
+ * canonical /shop and /shop?category=X views stay indexable.
+ */
+export const hasShopFilterParams = (search = "") => {
+  const params = new URLSearchParams(search);
+  return [...params.keys()].some((key) => {
+    const normalized = key.toLowerCase();
+    return !BENIGN_SHOP_PARAMS.has(normalized) && !normalized.startsWith("utm_");
+  });
+};
+


### PR DESCRIPTION
## What changed

**1. Real crawlable body content for product and category/SEO pages** (`api/product-page.js`, `api/seo-page.js`)
- These serverless functions already fetched real product/page data server-side but only injected `<head>` meta tags. They now also inject a small block directly inside `<div id="root">`: an `<h1>` with the real name/title, a `<p>` with the real description, and a `<nav>` of plain `<a>` breadcrumb links (Home → Shop → Category → Product, using real `href`s like `/shop?category=X`).
- `main.jsx` mounts with `createRoot()`, not `hydrateRoot()` — React fully replaces `#root`'s contents on mount rather than diffing against them, so there's no hydration mismatch and the injected markup is simply discarded once JS runs.
- Product page breadcrumb `BreadcrumbList` JSON-LD now includes the category crumb too (previously Home → Shop → Product only), generated from the same array as the visible links so the two can't disagree.

**2. Organization JSON-LD moved to static `index.html`** (`index.html`, `src/components/Common/RouteSeo.jsx`)
- `ORGANIZATION_SCHEMA` was only injected client-side on the homepage via `SeoHelmet`'s `structuredData` prop — it required JS to appear at all, and (since the root `/` doesn't match any `api/seo-page.js` rewrite in `vercel.json`) there was no server-rendered Organization schema either.
- It's now a static `<script type="application/ld+json">` block in `index.html`, present in the raw HTML unconditionally. Removed only that one constant/prop from `RouteSeo.jsx`; per-route Product/BreadcrumbList/FAQPage JSON-LD is untouched.

**3. Server/client robots mismatch on filtered `/shop` URLs** (`api/seo-page.js`, `src/utils/shopSeo.js`, `RouteSeo.jsx`)
- Added `hasShopFilterParams()` (client, in `shopSeo.js`) and its server equivalent in `seo-page.js`: true when `/shop` has query params beyond `category`/`page`/`sort`/`view`/`gclid`/`fbclid`/`utm_*` (i.e. real facets like color/size/price).
- `/shop` and `/shop?category=X` stay `index, follow` on both sides; `/shop?category=X&color=Y` etc. now get `noindex, follow` on both sides. Verified with curl (see below) — filtered URLs flipped from `index, follow` to `noindex, follow` server-side to match the client.

**4. Route-based code splitting** (`src/App.jsx`)
- Checkout and account (`/checkout`, `/my-account`) were already `React.lazy()` from an earlier PR. The remaining ~700KB-gzip main entry chunk — served on every route — turned out to come from `Home` and `ProductPageResolver` being imported eagerly; both pull in swiper/slick/lightgallery through their sub-components.
- Lazy-loaded both. They already render inside the existing `<Suspense>` boundary in `App.jsx`, so this is a drop-in change with no synchronous-availability requirement broken.
- Measured main chunk: **2,371.69 kB / 700.88 kB gzip → 1,838.41 kB / 545.95 kB gzip** (~22% smaller gzip), with `Home` (55.84 kB / 15.99 kB gzip) and `ProductPageResolver` (348.07 kB / 100.68 kB gzip) now split into their own chunks loaded only on those routes.

Out of scope per instructions: no SSR/SSG migration, no backlink work, no Google Search Console setup (needs the business owner's own Google account).

## Adversarial review round 2 — response to "MERGE AFTER CHANGES/VALIDATION"

An independent review (ChatGPT, acting as reviewer in our dual-LLM dev/test workflow) found five real gaps before this could merge. Here's what changed in response to each:

**1. HIGH — test gap: `#root` injection was never actually exercised.**
`seoPageHandler.test.js`'s fixtures were `<html><head>...</head><body></body></html>` — no `<div id="root"></div>` — so `injectBody()` had nothing to match and silently no-opped every time. Every assertion only checked `<head>` tags, so the suite would stay green even if body injection were completely broken.
- Fixed every fixture to include a real `<div id="root"></div>` mount point.
- Added regression tests (in `seoPageHandler.test.js`) proving: category/CMS page H1 + description + breadcrumb are actually injected into `#root`; a hostile blog title/description (`<script>`, `<img onerror=...>`, quotes, `&`) is sanitized with no surviving `<script>`/`<img>` tag anywhere in the response; faceted `/shop` URLs (color/size/price) get `noindex, follow` while plain `/shop` and `/shop?category=X` stay `index, follow`; and the handler returns valid, uncorrupted HTML (still full `<head>`/`<title>` tags, no `undefined`/`[object Object]` leakage) when `#root` is missing from the shell.
- `api/product-page.js` had **no dedicated test file at all** — added `productPageHandler.test.js` covering the same `#root` injection, hostile-input escaping, and missing-`#root` fail-safe cases, plus a test that the product's category is identical in both the visible breadcrumb `<a>` and the `BreadcrumbList` JSON-LD `item`/`name`.
- `hasShopFilterParams()` in `src/utils/shopSeo.js` (the client-side noindex decision) had zero direct test coverage — added unit tests in `dynamicSeo.test.js`.
- Added `routeSeoShopFilters.test.jsx`, mounting `RouteSeo` to assert the client-side `<meta name="robots">` tag actually matches the server-side decision for filtered vs. plain `/shop` URLs (previously nothing asserted the client half of this at all).
- Net: **+50 tests** (1765 → 1815 passing), across 2 new test files and additions to 2 existing ones.

**2. MEDIUM — sequencing/rebase.**
This branch was based on `bweb-dev` from before PR #168 (GA4/Meta Pixel/Clarity analytics) merged. Rebased onto the current `origin/bweb-dev` tip (commit `3c7e45f`). The rebase itself was git-clean — no conflicting hunks in `index.html` or `App.jsx` — but it exposed one real semantic conflict: PR #168's `appPageView.test.jsx` asserted on `Home`/`ProductPageResolver` synchronously via `getByText`, and this PR's own change (item 4 above) made both of those lazy-loaded behind `Suspense`, so the mocked modules now resolve asynchronously. Fixed by switching those two assertions to `findByText` (which awaits). Both PR #168's analytics changes and this PR's SEO changes are intact post-rebase; full suite is green.

**3. MEDIUM — raw HTML vs. rendered DOM parity.**
Checked every representative page type by reading the actual rendered component tree (not just the SSR code):
- **Product page (standard, `ProducPage` → `ProductDetails/index.jsx`)**: found a real mismatch — the product name rendered as an `<h2>`, not an `<h1>`, so after `createRoot()` replaces `#root` there was **no `<h1>` at all** on this page type despite the SSR shell always injecting one. **Fixed** — changed it to a real `<h1>` (tag-only change; `src/index.css` styles `h1`–`h6` identically, so no visual/CSS impact). `ClothingHeadwearProductPage` already used a real `<h1>` for the same element, so this brings the two product page variants in line with each other.
- **Product page breadcrumb** (`ProductNavigate.jsx`, standard variant): renders "Home / Product / {type_group_name} / {type_name}" from a different taxonomy field than the SSR breadcrumb ("Home / Shop / {category} / {product name}"), and the clothing/headwear product page renders no client-side breadcrumb at all. **Not fixed in this PR** — rewriting visible breadcrumb navigation is a real UX/IA change (different link targets, different taxonomy source), not a tag-level fix, and doing it without design review risks a visible regression on a currently-shipping page. Documented here so it isn't lost; recommend a follow-up PR scoped specifically to unifying breadcrumb taxonomy across product page variants and the SSR layer.
- **About page** (`ABoutHero.jsx`): the SSR H1 for `/about` is "About Super Merch Australia" (from `STATIC_PAGES` in `api/seo-page.js`); the client-rendered `<h1>` is "Welcome to Super Merch" — different marketing copy entirely. **Not fixed in this PR** — this is a content/voice decision on a live marketing page, not a code bug; changing it needs sign-off from whoever owns that copy, not a unilateral rewrite. Documented here as an open item.
- **Category/`/shop` pages** (`ShopPage.jsx`, `CategoryPage.jsx`, `CategoryGrid`/`Cards`): there is **no client-rendered `<h1>` at all** matching the SSR category H1 today — same gap pattern as the product breadcrumb. Documented as an open item; recommend it be tackled together with the product-breadcrumb follow-up since both are "add missing/duplicate crawlable structure to already-shipping page trees," not new SEO plumbing.
- Net for this item: one real fix landed (product H1 tag); three real gaps found and clearly documented rather than papered over with an unreviewed rewrite of live navigation/marketing copy.

**4. LOW/documentation — homepage scope.**
Confirmed and left alone per instructions: `/` gets only the static Organization JSON-LD from `index.html` (item 2 above). There is no server-injected H1/body content for the homepage — the highest-traffic route on the site. This remains **explicitly out of scope** for this PR; it needs its own SSR/content-injection design (the homepage's structure is materially different from a product/category page), not a quick win. Flagging again here so it isn't silently dropped a second time.

**5. LOW — perf validation.**
No Lighthouse/CI performance tooling is available in this environment (no `lighthouse`/`@lhci` in `package.json`, no way to run a real Chrome trace against a deployed preview here). Re-ran `npm run build` on the final, rebased code to confirm the bundle-size numbers still hold: main chunk **1,843.88 kB / 547.74 kB gzip**, `Home` split into its own **55.84 kB / 16.00 kB gzip** chunk, `ProductPageResolver` into **348.07 kB / 100.68 kB gzip** — consistent with the ~22% gzip reduction claimed originally. Real LCP/INP measurement on Home and a product page (before/after) is still **not done** and still needed before treating the perf claim as validated — someone with access to a deployed preview + Lighthouse/PageSpeed Insights or Vercel's own Web Analytics should run that check.

## Verification

Ran a local harness (Node importing the two handler modules directly, mocked `req`/`res`, shell fetched from a local `vite preview` of `dist/`) against the real production backend API, plus `npm run build`, `npm run lint`, and `npm test`.

- **#1**, product page (`/api/product-page?slug=dispenser-stand-11&id=2`) — raw HTML body now contains:
  ```html
  <div id="root">
  <div data-ssr-content="product">
  <nav aria-label="Breadcrumb"><a href="/">Home</a> / <a href="/shop">Shop</a> / <a href="/shop?category=Misc%20Health%20%26%20Personal">Misc Health &amp; Personal</a> / <span>Dispenser Stand 11</span></nav>
  <h1>Dispenser Stand 11</h1>
  <p>The Dispenser Stand is a great way to display your branding, and keep safe...</p>
  </div></div>
  ```
  Confirmed the same real content on `/api/seo-page?path=/shop&category=Clothing` and `/api/seo-page?path=/about`.
- **#2**: `curl http://localhost:4173/` (built `dist/index.html`) shows the Organization `<script type="application/ld+json">` block in raw HTML.
- **#3**:
  ```
  /shop                              -> <meta name="robots" content="index, follow">
  /shop?category=Clothing            -> <meta name="robots" content="index, follow">
  /shop?category=Clothing&color=Red  -> <meta name="robots" content="noindex, follow">
  ```
- **#4**: `npm run build` output confirms `Home-*.js` and `ProductPageResolver-*.js` as separate chunks; main `index-*.js` gzip size dropped as noted above.
- `npm run lint` on touched files: 0 new errors/warnings. Full `npm run lint` reports 1399 pre-existing problems (1333 errors, 66 warnings) — confirmed via `git stash` that this exact count is unchanged with or without this PR's changes applied, i.e. 100% pre-existing repo-wide debt, not introduced here.
- `npm test`: **1815/1815 passing** (30 files) — up from 1765 before this round of fixes, +50 net new tests: `seoPageHandler.test.js` (4 → 13), new `productPageHandler.test.js` (4), new `routeSeoShopFilters.test.jsx` (6), `dynamicSeo.test.js` (3 → 10), plus the 24 tests carried over from PR #168 via the rebase (`analytics.test.js`, `analyticsMiddleware.test.js`, `checkoutPurchaseTracking.test.jsx`, `appPageView.test.jsx` — the last one patched for lazy-loading as noted in item 2 above).
- `npm run build`: succeeds, multiple chunks produced as expected.

## Residual risk

- Item 1's body-content injection is regex-based (`<div id="root"></div>` → `<div id="root">...</div>`). It's scoped to this exact string, matching the current `index.html`/build output; if that markup ever changes shape, injection would silently no-op (fall back to head-only, current behavior) rather than break rendering, since it's a plain `.replace()` with no match required — now directly covered by the "fails safely without `#root`" tests in both handler test files.
- No hydration mismatch is expected in any case, since the app uses `createRoot()` — but this assumes `main.jsx` never switches to `hydrateRoot()` in the future without revisiting this injection.
- Item 4: `Home` and `ProductPageResolver` are the two highest-traffic routes. Lazy-loading them trades a small one-time chunk fetch (mitigated by HTTP/2 and the existing `<Suspense>` fallback) for a smaller shared bundle on every other route. This is a deliberate call since the app is 100% client-rendered (no SSR/hydration to preserve) and it was the only remaining lever to shrink the "same big bundle on every route" bundle the audit flagged — flagging it explicitly since the audit's own prioritization language ("least-universally-needed first") could be read as excluding these two routes.
- Item 3's canonical-vs-filtered split treats `category` alone as the canonical per-category view (kept indexable) and anything else as a facet (noindexed) — matches how `api/seo-page.js` already scopes SEO overrides and canonical URLs by category, but is a judgment call the audit's wording didn't spell out precisely.
- **Still open (see "Adversarial review round 2" above, items 3–5)**: product-page breadcrumb taxonomy mismatch, missing client-side breadcrumb on clothing/headwear product pages, About page H1 copy mismatch, missing client-side H1 on category/`/shop` pages, homepage body-content SSR (explicitly out of scope), and real Lighthouse/LCP/INP validation. None of these block merge on their own — they're pre-existing gaps this review surfaced, not regressions from this PR — but they should become follow-up tickets rather than being forgotten.


## Adversarial review rounds 3–9 — category-ID taxonomy and validity (response to further findings)

A second wave of independent review found real bugs in how `?category=` values are resolved and validated. Summary of what changed, most recent first:

- **Stale examples above are now invalid input.** The curl examples earlier in this description use `category=Clothing` — a human-readable label, not a real product-type ID. Under the validity check added below, that value is treated as **invalid** (canonicalizes to `/shop`, `noindex, follow`), not indexable as shown above. Real category IDs look like `PE-02` (Drink Bottles); see `scripts/category-finder/authoritative-category-ids.json` for the full 297-leaf + 27-parent inventory.
- **Atomic taxonomy pairing** (`api/product-page.js`): the category label (`type_name`) and its ID (`type_id`) must come from the *same* taxonomy object (`promodata_product_type` or `product_type`), never mixed across objects — otherwise the breadcrumb/JSON-LD could describe one category while linking to another. Covered by regression tests for both mismatch directions.
- **Category-ID validity gating** (`api/seo-page.js`): `/shop?category=X` is only self-canonical/`index, follow` when `X` is a real leaf/parent ID from the authoritative inventory. An invalid/arbitrary value canonicalizes to plain `/shop` and gets `noindex, follow` — admin SEO override presence is never used as the validity signal, and an invalid category's SEO override (if one exists) is now ignored entirely so it can't leak a stale canonical through.
- **Client/server parity** (`src/utils/categoryValidity.js`, `src/utils/shopSeo.js`, `RouteSeo.jsx`): category validation now lives in one shared, browser-compatible module (no `node:fs`) imported by both the serverless function and the client, so React can never overwrite the server's correct tags after hydration with a contradictory one. Covered by mounted `RouteSeo` tests asserting the final DOM canonical/robots for all 4 cases (plain `/shop`, valid category, invalid category, valid category + facet).

Non-blocking maintenance note carried over from review: the category inventory snapshot needs periodic regeneration as the real catalogue changes, or newly added legitimate categories will be temporarily treated as invalid until the next regeneration.
