### PR TITLE
Fix homepage SSR: stop Vercel from serving dist/index.html statically

### DIFF
--- a/api/app-shell.js
+++ b/api/app-shell.js
@@ -66,17 +66,17 @@ const injectHead = (html, tags) => {
 };
 
 // Reads the built SPA shell straight off disk instead of self-fetching "/"
-// over HTTP. On Vercel, a request matching an actual static file (dist/
-// index.html at "/") is served directly and never reaches rewrites at all —
-// so as long as any function depends on fetching "/" live, "/" itself can
-// never be rewritten to a function. Reading the on-disk build artifact
-// removes that dependency entirely and is what makes the "/" → seo-page
-// rewrite (see vercel.json) safe to add. Cached in module scope so warm
-// lambda instances pay the disk read only once.
+// over HTTP or reading dist/index.html directly. Vercel serves an exact
+// static-file match (dist/index.html at "/") before ever consulting
+// vercel.json's rewrites, regardless of what any function depends on --
+// so the "vercel-build" script (see package.json) copies index.html to
+// this filename and deletes the original, leaving no static file at "/"
+// for Vercel to intercept the "/" -> seo-page rewrite with. Cached in
+// module scope so warm lambda instances pay the disk read only once.
 let cachedShell = null;
 const getShell = () => {
   if (!cachedShell) {
-    cachedShell = readFileSync(join(process.cwd(), "dist", "index.html"), "utf8");
+    cachedShell = readFileSync(join(process.cwd(), "dist", "_shell.html"), "utf8");
   }
   return cachedShell;
 };

--- a/api/product-page.js
+++ b/api/product-page.js
@@ -231,17 +231,17 @@ const getSeoOverride = async (entityId) => {
 };
 
 // Reads the built SPA shell straight off disk instead of self-fetching "/"
-// over HTTP. On Vercel, a request matching an actual static file (dist/
-// index.html at "/") is served directly and never reaches rewrites at all —
-// so as long as any function depends on fetching "/" live, "/" itself can
-// never be rewritten to a function. Reading the on-disk build artifact
-// removes that dependency entirely and is what makes the "/" → seo-page
-// rewrite (see vercel.json) safe to add. Cached in module scope so warm
-// lambda instances pay the disk read only once.
+// over HTTP or reading dist/index.html directly. Vercel serves an exact
+// static-file match (dist/index.html at "/") before ever consulting
+// vercel.json's rewrites, regardless of what any function depends on --
+// so the "vercel-build" script (see package.json) copies index.html to
+// this filename and deletes the original, leaving no static file at "/"
+// for Vercel to intercept the "/" -> seo-page rewrite with. Cached in
+// module scope so warm lambda instances pay the disk read only once.
 let cachedShell = null;
 const getShell = () => {
   if (!cachedShell) {
-    cachedShell = readFileSync(join(process.cwd(), "dist", "index.html"), "utf8");
+    cachedShell = readFileSync(join(process.cwd(), "dist", "_shell.html"), "utf8");
   }
   return cachedShell;
 };

--- a/api/seo-page.js
+++ b/api/seo-page.js
@@ -504,17 +504,17 @@ const hasShopFilterParams = (query) =>
   });
 
 // Reads the built SPA shell straight off disk instead of self-fetching "/"
-// over HTTP. On Vercel, a request matching an actual static file (dist/
-// index.html at "/") is served directly and never reaches rewrites at all —
-// so as long as any function depends on fetching "/" live, "/" itself can
-// never be rewritten to a function. Reading the on-disk build artifact
-// removes that dependency entirely and is what makes the "/" → seo-page
-// rewrite (see vercel.json) safe to add. Cached in module scope so warm
-// lambda instances pay the disk read only once.
+// over HTTP or reading dist/index.html directly. Vercel serves an exact
+// static-file match (dist/index.html at "/") before ever consulting
+// vercel.json's rewrites, regardless of what any function depends on --
+// so the "vercel-build" script (see package.json) copies index.html to
+// this filename and deletes the original, leaving no static file at "/"
+// for Vercel to intercept the "/" -> seo-page rewrite with. Cached in
+// module scope so warm lambda instances pay the disk read only once.
 let cachedShell = null;
 const getShell = () => {
   if (!cachedShell) {
-    cachedShell = readFileSync(join(process.cwd(), "dist", "index.html"), "utf8");
+    cachedShell = readFileSync(join(process.cwd(), "dist", "_shell.html"), "utf8");
   }
   return cachedShell;
 };

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "vercel-build": "vite build && node scripts/prepare-vercel-shell.mjs",
     "lint": "eslint .",
     "preview": "vite preview",
     "start": "vite preview --host 0.0.0.0",

--- a/scripts/prepare-vercel-shell.mjs
+++ b/scripts/prepare-vercel-shell.mjs
@@ -1,0 +1,36 @@
+import { copyFileSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+const distDir = join(process.cwd(), "dist");
+const indexPath = join(distDir, "index.html");
+const shellPath = join(distDir, "_shell.html");
+
+if (!existsSync(indexPath)) {
+  throw new Error(
+    "dist/index.html not found after build -- cannot prepare the SSR shell copy",
+  );
+}
+
+// Vercel serves an exact static-file match (dist/index.html at "/") before
+// ever consulting vercel.json's rewrites -- so as long as this file exists
+// at the deploy output root, the "/" -> api/seo-page rewrite can never
+// fire, and the homepage stays the empty, un-server-rendered shell (the
+// incident this fixes -- see getShell() in api/seo-page.js). Copy it to a
+// name no real route will ever request, then remove the original so
+// there's no static match left for Vercel to intercept "/" with. The
+// three SSR functions (api/product-page.js, api/seo-page.js,
+// api/app-shell.js) read this copy via their own getShell(), bundled in
+// via vercel.json's includeFiles -- unaffected by this rename, since
+// Vercel bundles function files from this same build output after this
+// script has already run.
+//
+// This only runs as part of the Vercel-specific "vercel-build" npm script
+// (see package.json + vercel.json's buildCommand) -- never as part of the
+// plain "build" script, so local dev, `npm run build`, `vite preview`, and
+// every test (which mocks node:fs and never touches a real file) are all
+// completely unaffected.
+copyFileSync(indexPath, shellPath);
+rmSync(indexPath);
+console.log(
+  'Prepared dist/_shell.html for the SSR functions and removed dist/index.html so Vercel\'s "/" rewrite can actually fire.',
+);

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "buildCommand": "npm run vercel-build",
   "functions": {
     "api/sitemap-index.js": {
       "maxDuration": 60
@@ -11,13 +12,13 @@
     },
     "api/seo-page.js": {
       "maxDuration": 60,
-      "includeFiles": "dist/index.html"
+      "includeFiles": "dist/_shell.html"
     },
     "api/product-page.js": {
-      "includeFiles": "dist/index.html"
+      "includeFiles": "dist/_shell.html"
     },
     "api/app-shell.js": {
-      "includeFiles": "dist/index.html"
+      "includeFiles": "dist/_shell.html"
     }
   },
   "rewrites": [


### PR DESCRIPTION
## Background
PR #171 added a `"/" -> api/seo-page` rewrite intended to fix the empty homepage (the audit's #1 Critical item). Independently re-verified live in production today (curl against `https://www.supermerch.com.au/`, including with a cache-busting query string to rule out CDN staleness): the homepage's raw `<body>` is still exactly `<div id="root"></div>` -- the fix does not actually work.

Root cause: Vercel serves an exact static-file match (`dist/index.html` at `/`) before ever consulting `vercel.json`'s `rewrites`, regardless of what any function depends on internally. PR #171's fix (reading the shell via `readFileSync` instead of self-fetching `/` over HTTP) was a real improvement for reliability, but it doesn't change this routing precedence -- the rewrite still never fires because the static file still exists at the deploy output root.

## Fix
A Vercel-only `vercel-build` npm script (`vite build && node scripts/prepare-vercel-shell.mjs`) copies `dist/index.html` to `dist/_shell.html` and deletes the original after build, so there's no static file left at `/` for Vercel to intercept the rewrite with. All three SSR functions (`api/product-page.js`, `api/seo-page.js`, `api/app-shell.js`) now read `dist/_shell.html` instead, and `vercel.json`'s `includeFiles`/new `buildCommand` are updated to match.

Local dev, `npm run build`, `vite preview`, and every existing test are unaffected: `npm run build` still runs plain `vite build` and produces a normal `dist/index.html`; tests mock `node:fs` entirely (confirmed by reading the actual test setup) so they never touch a real file on disk either way. Only Vercel's own deployment build runs the extra rename step.

## Test plan
- [x] Full test suite: 1835/1835 passing (1 unrelated pre-existing flake in `appPageView.test.jsx`, confirmed passing in isolation, untouched by this PR).
- [x] Lint clean on all changed files.
- [x] `npm run build` (plain) still produces `dist/index.html` normally -- confirmed local dev/preview untouched.
- [x] `npm run vercel-build` produces exactly the intended layout: `dist/index.html` gone, `dist/_shell.html` present with the correct shell content.
- [x] **Verified against this PR's own Vercel preview deployment** (via an authenticated browser session, since the preview is behind Vercel deployment protection): fetched `/` directly with a cache-busting query string. Before this fix: 6178 bytes, empty `<div id="root"></div>`. After: status 200, 7249 bytes, real `<h1>`, "Top categories" nav present, no empty-root marker. This is exactly the live-verification step PR #171 skipped, and the class of bug a local/unit-test-only check cannot catch.
- [x] Re-verified `/cart` (200, shell as intended -- a real client-only route, not meant to be indexed), `/checkout` (200, shell as intended), `/Cart` (redirects to `/cart`, final status 200), a nonsense path (real 404), and `/shop` (200, product links still present, 7953 bytes) -- all confirmed on the preview, no regression from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
