### PR TITLE
Move the SSR shell outside the public output so it isn't an indexable URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,7 @@ scripts/category-finder/.snapshot/
 # sample product ids) -- regenerate with verify-filter-mappings.mjs. The
 # compact, committed companion is scripts/category-finder/verification-summary.json.
 scripts/category-finder/.evidence/
+# SSR shell copy written by scripts/prepare-vercel-shell.mjs during the
+# Vercel-only "vercel-build" script. Regenerated on every deploy and kept
+# outside dist/ so it is never served as a public URL -- never committed.
+/server-assets/

--- a/api/app-shell.js
+++ b/api/app-shell.js
@@ -69,14 +69,20 @@ const injectHead = (html, tags) => {
 // over HTTP or reading dist/index.html directly. Vercel serves an exact
 // static-file match (dist/index.html at "/") before ever consulting
 // vercel.json's rewrites, regardless of what any function depends on --
-// so the "vercel-build" script (see package.json) copies index.html to
-// this filename and deletes the original, leaving no static file at "/"
-// for Vercel to intercept the "/" -> seo-page rewrite with. Cached in
+// so the "vercel-build" script (see package.json) copies index.html here
+// and deletes the original, leaving no static file at "/" for Vercel to
+// intercept the "/" -> seo-page rewrite with. The copy lives outside dist
+// on purpose: files in the public output are reachable as URLs, and an
+// earlier dist/_shell.html left an empty indexable page served at
+// /_shell.html. vercel.json's includeFiles still bundles it in. Cached in
 // module scope so warm lambda instances pay the disk read only once.
 let cachedShell = null;
 const getShell = () => {
   if (!cachedShell) {
-    cachedShell = readFileSync(join(process.cwd(), "dist", "_shell.html"), "utf8");
+    cachedShell = readFileSync(
+      join(process.cwd(), "server-assets", "app-shell.html"),
+      "utf8",
+    );
   }
   return cachedShell;
 };

--- a/api/product-page.js
+++ b/api/product-page.js
@@ -234,14 +234,20 @@ const getSeoOverride = async (entityId) => {
 // over HTTP or reading dist/index.html directly. Vercel serves an exact
 // static-file match (dist/index.html at "/") before ever consulting
 // vercel.json's rewrites, regardless of what any function depends on --
-// so the "vercel-build" script (see package.json) copies index.html to
-// this filename and deletes the original, leaving no static file at "/"
-// for Vercel to intercept the "/" -> seo-page rewrite with. Cached in
+// so the "vercel-build" script (see package.json) copies index.html here
+// and deletes the original, leaving no static file at "/" for Vercel to
+// intercept the "/" -> seo-page rewrite with. The copy lives outside dist
+// on purpose: files in the public output are reachable as URLs, and an
+// earlier dist/_shell.html left an empty indexable page served at
+// /_shell.html. vercel.json's includeFiles still bundles it in. Cached in
 // module scope so warm lambda instances pay the disk read only once.
 let cachedShell = null;
 const getShell = () => {
   if (!cachedShell) {
-    cachedShell = readFileSync(join(process.cwd(), "dist", "_shell.html"), "utf8");
+    cachedShell = readFileSync(
+      join(process.cwd(), "server-assets", "app-shell.html"),
+      "utf8",
+    );
   }
   return cachedShell;
 };

--- a/api/seo-page.js
+++ b/api/seo-page.js
@@ -507,14 +507,20 @@ const hasShopFilterParams = (query) =>
 // over HTTP or reading dist/index.html directly. Vercel serves an exact
 // static-file match (dist/index.html at "/") before ever consulting
 // vercel.json's rewrites, regardless of what any function depends on --
-// so the "vercel-build" script (see package.json) copies index.html to
-// this filename and deletes the original, leaving no static file at "/"
-// for Vercel to intercept the "/" -> seo-page rewrite with. Cached in
+// so the "vercel-build" script (see package.json) copies index.html here
+// and deletes the original, leaving no static file at "/" for Vercel to
+// intercept the "/" -> seo-page rewrite with. The copy lives outside dist
+// on purpose: files in the public output are reachable as URLs, and an
+// earlier dist/_shell.html left an empty indexable page served at
+// /_shell.html. vercel.json's includeFiles still bundles it in. Cached in
 // module scope so warm lambda instances pay the disk read only once.
 let cachedShell = null;
 const getShell = () => {
   if (!cachedShell) {
-    cachedShell = readFileSync(join(process.cwd(), "dist", "_shell.html"), "utf8");
+    cachedShell = readFileSync(
+      join(process.cwd(), "server-assets", "app-shell.html"),
+      "utf8",
+    );
   }
   return cachedShell;
 };

--- a/scripts/prepare-vercel-shell.mjs
+++ b/scripts/prepare-vercel-shell.mjs
@@ -1,9 +1,10 @@
-import { copyFileSync, rmSync, existsSync } from "node:fs";
+import { copyFileSync, mkdirSync, rmSync, existsSync } from "node:fs";
 import { join } from "node:path";
 
 const distDir = join(process.cwd(), "dist");
 const indexPath = join(distDir, "index.html");
-const shellPath = join(distDir, "_shell.html");
+const shellDir = join(process.cwd(), "server-assets");
+const shellPath = join(shellDir, "app-shell.html");
 
 if (!existsSync(indexPath)) {
   throw new Error(
@@ -15,22 +16,31 @@ if (!existsSync(indexPath)) {
 // ever consulting vercel.json's rewrites -- so as long as this file exists
 // at the deploy output root, the "/" -> api/seo-page rewrite can never
 // fire, and the homepage stays the empty, un-server-rendered shell (the
-// incident this fixes -- see getShell() in api/seo-page.js). Copy it to a
-// name no real route will ever request, then remove the original so
-// there's no static match left for Vercel to intercept "/" with. The
-// three SSR functions (api/product-page.js, api/seo-page.js,
-// api/app-shell.js) read this copy via their own getShell(), bundled in
-// via vercel.json's includeFiles -- unaffected by this rename, since
-// Vercel bundles function files from this same build output after this
-// script has already run.
+// incident this fixes -- see getShell() in api/seo-page.js). So copy the
+// shell somewhere the three SSR functions can still read it, then remove
+// the original so there's no static match left to intercept "/" with.
+//
+// The copy deliberately lands OUTSIDE dist: anything inside the public
+// output directory is reachable as a URL, so an earlier version of this
+// script that wrote dist/_shell.html left an empty, indexable page served
+// at /_shell.html that declared itself "index, follow" and claimed the
+// homepage as its canonical -- the exact thin-content problem the SSR work
+// exists to remove. Files outside the public output are never served to
+// visitors, while vercel.json's includeFiles still packages this one into
+// each function bundle, so the functions keep working and the URL simply
+// doesn't exist. Note that noindex-ing /_shell.html instead would be
+// weaker: robots.txt cannot be used to suppress it (a URL must be
+// crawlable for a noindex to be seen at all), so removing the URL is the
+// only complete fix.
 //
 // This only runs as part of the Vercel-specific "vercel-build" npm script
 // (see package.json + vercel.json's buildCommand) -- never as part of the
 // plain "build" script, so local dev, `npm run build`, `vite preview`, and
 // every test (which mocks node:fs and never touches a real file) are all
 // completely unaffected.
+mkdirSync(shellDir, { recursive: true });
 copyFileSync(indexPath, shellPath);
 rmSync(indexPath);
 console.log(
-  'Prepared dist/_shell.html for the SSR functions and removed dist/index.html so Vercel\'s "/" rewrite can actually fire.',
+  'Prepared server-assets/app-shell.html for the SSR functions and removed dist/index.html so Vercel\'s "/" rewrite can actually fire.',
 );

--- a/vercel.json
+++ b/vercel.json
@@ -12,13 +12,13 @@
     },
     "api/seo-page.js": {
       "maxDuration": 60,
-      "includeFiles": "dist/_shell.html"
+      "includeFiles": "server-assets/app-shell.html"
     },
     "api/product-page.js": {
-      "includeFiles": "dist/_shell.html"
+      "includeFiles": "server-assets/app-shell.html"
     },
     "api/app-shell.js": {
-      "includeFiles": "dist/_shell.html"
+      "includeFiles": "server-assets/app-shell.html"
     }
   },
   "rewrites": [


### PR DESCRIPTION
## Background

PR #172 fixed the empty homepage by having the Vercel-only build step rename `dist/index.html` to `dist/_shell.html`, so no static file is left at `/` to pre-empt the `/` → `api/seo-page` rewrite. That worked — the homepage now server-renders correctly in production.

But the renamed copy stayed **inside** the public output directory, so it is served as a real URL. Confirmed live on production after the #172 deploy:

```
GET https://www.supermerch.com.au/_shell.html
200, 6174 bytes
<div id="root"></div>            (empty)
<meta name="robots" content="index, follow">
<link rel="canonical" href="https://www.supermerch.com.au/">
```

An empty page that explicitly invites indexing and claims the homepage as its canonical — the same thin-content pattern the SSR work exists to eliminate. Nothing links to it and it is absent from the sitemap, so practical risk is low (`/index.html` correctly returns 404 now), but the URL should not exist at all.

Reviewed independently by ChatGPT, which rated it **low SEO risk** — not security-critical, not an order/checkout blocker — but agreed it should be cleaned up, and recommended this approach over the `noindex` header I had originally proposed.

## Fix

The shell now goes to `server-assets/app-shell.html`, outside `dist`. Files outside the public output are never served to visitors, while `vercel.json`'s `includeFiles` still packages it into each of the three SSR function bundles. `dist/index.html` is still deleted, so the homepage rewrite keeps working exactly as it does now.

Changed: `scripts/prepare-vercel-shell.mjs`, the `getShell()` path in `api/seo-page.js` / `api/product-page.js` / `api/app-shell.js`, the three `includeFiles` entries in `vercel.json`, and a `.gitignore` entry for the generated directory.

### Why not just `noindex` it

Strictly weaker, and the reason is worth recording. A `robots.txt` `Disallow` **cannot** suppress the URL: a page has to be crawlable for a `noindex` to be seen at all, and robots-blocked URLs can still surface in search results. Removing the URL is the only complete fix.

## Test plan

- [x] `npm run vercel-build` leaves **no `.html` at the dist root at all** — no `index.html`, no `_shell.html` — and writes `server-assets/app-shell.html` (6308 bytes) containing the root div and the correct hashed bundle reference.
- [x] Plain `npm run build` still produces a normal `dist/index.html`, so local dev, `vite preview` and the tracked `dist/` are untouched.
- [x] `eslint` clean on all changed files.
- [x] 1835/1835 tests pass (31 files), including `appPageView.test.jsx`, which flaked once during the #172 work and is clean here. The handler tests mock `node:fs` and never read a real path, so none of them reference this location — confirmed by grep, not assumption.
- [x] **Verified on this PR's authenticated Vercel preview** (Vercel green, CodeRabbit green). `/_shell.html` now returns **404** (was 200) and `/index.html` returns 404, both with `noindex` and canonical stripped — neither is an indexable URL any more. Every other path is byte-identical to the values verified for #172, i.e. zero regression: `/` 200/7249 (real H1, canonical=1, robots=1, 2× JSON-LD), `/Clothing` 200/8083, `/Headwear` 200/8059, `/all-blogs` 200/7150, `/shop` 200/6219, `/product/dispenser-stand/2` 200/8497 (3× JSON-LD), `/cart` + `/checkout` 200 noindex shell, `/Cart` → `/cart`, bogus path 404. Every response still carries `<div id="root">` plus its bundle script, so hydration is intact. Assets `index-DHEbGW7i.js` and `index-J-QzvAQp.css` both 200, zero 404s — confirming `includeFiles` correctly packaged the external `server-assets/app-shell.html` artifact into all three function bundles, which was the one deployment-specific risk in this change.
- [ ] Re-confirm the same checks on production after merge.

Depends on #172 (already merged as `c07a8d0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
